### PR TITLE
fix: Critical bugs pre-beta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,9 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# Supabase / API credentials — never commit real keys
+# Use --dart-define at build time or a local .env file
+.env
+.env.local
+lib/core/config/supabase_config.local.dart

--- a/lib/core/config/supabase_config.dart
+++ b/lib/core/config/supabase_config.dart
@@ -1,4 +1,28 @@
+// SECURITY: Do NOT hardcode credentials here.
+// Pass values at build time via --dart-define:
+//   flutter run \
+//     --dart-define=SUPABASE_URL=https://your-project.supabase.co \
+//     --dart-define=SUPABASE_ANON_KEY=your-anon-key
+//
+// For CI/CD, set SUPABASE_URL and SUPABASE_ANON_KEY as environment secrets
+// and pass them via --dart-define in your build script.
+//
+// See: https://docs.flutter.dev/deployment/obfuscate#dart-define
+
 class SupabaseConfig {
-  static const String url = 'https://api.devsalah.com';
-  static const String anonKey = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzdXBhYmFzZSIsImlhdCI6MTc3MTU1NTA4MCwiZXhwIjo0OTI3MjI4NjgwLCJyb2xlIjoiYW5vbiJ9.ZDOHExlWFENbOXhLtR2Jb-DXEbFGTvH4r3-JkEXn1T8';
+  // Values are injected at compile time via --dart-define.
+  // The fallback strings will cause Supabase init to fail loudly
+  // in debug mode if the defines are missing — intentional.
+  static const String url = String.fromEnvironment(
+    'SUPABASE_URL',
+    defaultValue: 'SUPABASE_URL_NOT_SET',
+  );
+
+  static const String anonKey = String.fromEnvironment(
+    'SUPABASE_ANON_KEY',
+    defaultValue: 'SUPABASE_ANON_KEY_NOT_SET',
+  );
+
+  static bool get isConfigured =>
+      url != 'SUPABASE_URL_NOT_SET' && anonKey != 'SUPABASE_ANON_KEY_NOT_SET';
 }

--- a/lib/features/balances/screens/group_detail_screen.dart
+++ b/lib/features/balances/screens/group_detail_screen.dart
@@ -53,10 +53,26 @@ class _GroupDetailScreenState extends ConsumerState<GroupDetailScreen>
       duration: const Duration(milliseconds: 250),
     );
     _groupName = widget.group.name;
+
+    // BUG-01 fix: Start realtime subscription here (not in HomeScreen) so
+    // that the lifecycle is owned by this widget. Wire the callback so
+    // incoming Postgres events actually invalidate Riverpod providers.
+    SyncService.instance.listenToGroup(widget.group.id);
+    SyncService.instance.onGroupChanged = (groupId) {
+      if (!mounted) return;
+      ref.invalidate(membersProvider(groupId));
+      ref.invalidate(expensesProvider(groupId));
+      ref.invalidate(settlementRecordsProvider(groupId));
+      ref.invalidate(activityProvider(groupId));
+      ref.invalidate(groupComputedDataProvider(groupId));
+    };
   }
 
   @override
   void dispose() {
+    // Clear the callback before stopping — avoids calling invalidate on a
+    // disposed ProviderContainer after the screen is gone.
+    SyncService.instance.onGroupChanged = null;
     SyncService.instance.stopListening(widget.group.id);
     _tabController.dispose();
     _fabAnimationController.dispose();

--- a/lib/features/expenses/providers/expenses_provider.dart
+++ b/lib/features/expenses/providers/expenses_provider.dart
@@ -93,6 +93,7 @@ class ExpensesNotifier extends FamilyAsyncNotifier<List<Expense>, String> {
     String splitType = 'equal',
     String currency = 'USD',
     DateTime? expenseDate,
+    DateTime? originalCreatedAt,
     Map<String, double>? customSplits,
   }) async {
     if (splitAmongIds.isEmpty) {
@@ -105,17 +106,21 @@ class ExpensesNotifier extends FamilyAsyncNotifier<List<Expense>, String> {
     final perPayerAmount = amount / paidByIds.length;
 
     final now = DateTime.now();
+    // Preserve the original createdAt — do NOT use DateTime.now() which would
+    // change sort order and break audit trail. BUG-03 fix.
+    final createdAt = originalCreatedAt ?? now;
     final expense = Expense(
       id: expenseId,
       description: description,
       amount: amount,
       paidById: paidByIds.first,
       groupId: arg,
-      createdAt: now,
-      expenseDate: expenseDate ?? now,
+      createdAt: createdAt,
+      expenseDate: expenseDate ?? createdAt,
       category: category,
       splitType: splitType,
       currency: currency,
+      updatedAt: now,
     );
 
     final splits = splitAmongIds.map((memberId) {

--- a/lib/features/expenses/screens/add_expense_screen.dart
+++ b/lib/features/expenses/screens/add_expense_screen.dart
@@ -33,6 +33,7 @@ class _AddExpenseScreenState extends ConsumerState<AddExpenseScreen> {
   final Map<String, TextEditingController> _splitControllers = {};
 
   bool get _isEditing => widget.expense != null;
+  bool _saving = false;
 
   // Categories from expense_category.dart
 
@@ -125,6 +126,7 @@ class _AddExpenseScreenState extends ConsumerState<AddExpenseScreen> {
   }
 
   Future<void> _saveExpense() async {
+    if (_saving) return; // Double-submit guard (BUG fix)
     final description = _descriptionController.text.trim();
 
     if (description.isEmpty) {
@@ -173,6 +175,7 @@ class _AddExpenseScreenState extends ConsumerState<AddExpenseScreen> {
       }
     }
 
+    setState(() => _saving = true);
     try {
       final notifier = ref.read(expensesProvider(widget.group.id).notifier);
       if (_isEditing) {
@@ -184,6 +187,9 @@ class _AddExpenseScreenState extends ConsumerState<AddExpenseScreen> {
           splitAmongIds: _selectedSplitMemberIds.toList(),
           category: _selectedCategory,
           splitType: _splitType,
+          customSplits: customSplits,
+          originalCreatedAt: widget.expense!.createdAt,
+          expenseDate: widget.expense!.expenseDate,
         );
         NotificationService.instance.showExpenseUpdated(
           groupName: widget.group.name,
@@ -216,6 +222,8 @@ class _AddExpenseScreenState extends ConsumerState<AddExpenseScreen> {
           SnackBar(content: Text('Error saving expense: $e')),
         );
       }
+    } finally {
+      if (mounted) setState(() => _saving = false);
     }
   }
 

--- a/lib/features/expenses/screens/add_expense_wizard.dart
+++ b/lib/features/expenses/screens/add_expense_wizard.dart
@@ -40,6 +40,7 @@ class _AddExpenseWizardState extends ConsumerState<AddExpenseWizard> {
   bool _membersInitialized = false;
   // Notifier to trigger targeted rebuilds for split validation only
   final ValueNotifier<int> _splitInputNotifier = ValueNotifier<int>(0);
+  bool _saving = false; // Double-submit guard
 
   @override
   void initState() {
@@ -134,6 +135,7 @@ class _AddExpenseWizardState extends ConsumerState<AddExpenseWizard> {
   }
 
   Future<void> _saveExpense() async {
+    if (_saving) return; // Double-submit guard
     final amount = _numpadAmount;
     final description = _descriptionController.text.trim();
 
@@ -155,6 +157,7 @@ class _AddExpenseWizardState extends ConsumerState<AddExpenseWizard> {
     }
 
     HapticFeedback.mediumImpact();
+    setState(() => _saving = true);
 
     final swTotal = Stopwatch()..start();
     debugPrint('[PERF] _saveExpense START');
@@ -206,6 +209,8 @@ class _AddExpenseWizardState extends ConsumerState<AddExpenseWizard> {
           SnackBar(content: Text('Error saving expense: $e')),
         );
       }
+    } finally {
+      if (mounted) setState(() => _saving = false);
     }
   }
 

--- a/lib/features/groups/repositories/group_repository.dart
+++ b/lib/features/groups/repositories/group_repository.dart
@@ -90,18 +90,35 @@ class GroupRepository with ApiFirstRepository {
   }
 
   Future<void> updateGroupName(String id, String name) async {
+    // BUG-05 fix: fetch the full group first so we can do a complete upsert.
+    // A partial upsert (id + name only) may violate NOT NULL constraints on
+    // the server or silently null out required fields like currency/type.
+    Group? existingGroup;
+    try {
+      existingGroup = await getGroup(id);
+    } catch (_) {
+      // If we can't fetch the group (e.g. offline), fall through to SQLite-only update
+    }
+
+    final now = DateTime.now();
     await writeThrough(
       apiCall: () async {
-        await api.upsert('groups', {
-          'id': id,
-          'name': name,
-          'updated_at': DateTime.now().toIso8601String(),
-        });
+        if (existingGroup != null) {
+          final fullMap = existingGroup.copyWith(name: name, updatedAt: now).toApiMap();
+          await api.upsert('groups', fullMap);
+        } else {
+          // Partial update as last resort — only name + updated_at
+          await api.upsert('groups', {
+            'id': id,
+            'name': name,
+            'updated_at': now.toIso8601String(),
+          });
+        }
       },
       sqliteCall: (database) async {
         await database.update(
           'groups',
-          {'name': name, 'updated_at': DateTime.now().toIso8601String()},
+          {'name': name, 'updated_at': now.toIso8601String()},
           where: 'id = ?',
           whereArgs: [id],
         );

--- a/lib/features/groups/screens/home_screen.dart
+++ b/lib/features/groups/screens/home_screen.dart
@@ -217,8 +217,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                     onTap: () {
                       debugPrint('[PERF] HomeScreen: tapped group "${group.name}" (${group.id})');
                       final sw = Stopwatch()..start();
-                      SyncService.instance.listenToGroup(group.id);
-                      debugPrint('[PERF] HomeScreen: listenToGroup done in ${sw.elapsedMilliseconds}ms');
+                      // BUG-06 fix: listenToGroup is now started in GroupDetailScreen.initState()
+                      // to ensure proper lifecycle ownership. Removed from here.
                       Navigator.push(
                         context,
                         slideRoute(GroupDetailScreen(group: group)),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -62,6 +62,15 @@ void main() async {
 }
 
 Future<void> _initSupabaseInBackground() async {
+  if (!SupabaseConfig.isConfigured) {
+    debugPrint(
+      '[SUPABASE] ⚠️  Missing config — run with:\n'
+      '  flutter run --dart-define=SUPABASE_URL=... --dart-define=SUPABASE_ANON_KEY=...\n'
+      '  App will run in local-only mode.',
+    );
+    return;
+  }
+
   try {
     await Supabase.initialize(
       url: SupabaseConfig.url,


### PR DESCRIPTION
## Summary

This PR fixes the 6 most critical bugs identified in the SeniorDev code review. All are pre-beta blockers — some would cause silent data loss in production.

---

## Bugs Fixed

### 🔴 BUG-01 — Realtime callback never wired (shared groups never update)
`SyncService.onGroupChanged` was declared but never assigned. Realtime Postgres changes were silently ignored — users in shared groups never saw updates from others without restarting the app.

**Fix:** Wire `onGroupChanged` in `GroupDetailScreen.initState()` to invalidate all relevant Riverpod providers. Move `listenToGroup()` lifecycle ownership from `HomeScreen` to `GroupDetailScreen`.

### 🔴 BUG-02 — customSplits dropped on expense edit → wrong amounts saved
When editing a non-equal-split expense, the `customSplits` map was calculated but never passed to `updateExpense()`. Splits were silently recalculated as equal-split and saved with wrong amounts.

**Fix:** Pass `customSplits: customSplits` to `updateExpense()` in `add_expense_screen.dart`.

### 🔴 BUG-03 — updateExpense overwrites createdAt with DateTime.now()
Every edit changed the expense creation timestamp to the current time, breaking sort order and audit trails.

**Fix:** Added `originalCreatedAt` parameter to `updateExpense()`. `AddExpenseScreen` now passes the original expense's `createdAt` through.

### 🟠 BUG-05 — Partial upsert in updateGroupName may corrupt server data
Rename sent only `{id, name, updated_at}` to Supabase. If the table has NOT NULL constraints on `currency`, `type`, or `created_at`, this either fails or nullifies them.

**Fix:** Fetch the full Group first, then upsert all fields via `copyWith(name: name)`.

### 🟠 BUG-06 — Realtime subscription lifecycle split across two widgets
`HomeScreen` started subscriptions; `GroupDetailScreen` stopped them. Navigating via deep link or join flow left subscriptions running without cleanup. Back-navigation + re-open would have no subscription at all.

**Fix:** `GroupDetailScreen` now owns the full lifecycle (start in `initState`, stop in `dispose`).

### 🔴 BUG-07 — Hardcoded Supabase credentials in source code
Credentials were committed directly in `supabase_config.dart`.

**Fix:** Moved to compile-time `--dart-define` injection (`SUPABASE_URL` / `SUPABASE_ANON_KEY`). App falls back to local-only mode with a clear log warning when defines are missing. Added `.env` and config files to `.gitignore`.

### 🟠 Double-submit guard
Fast double-tap on Save in both `AddExpenseScreen` and `AddExpenseWizard` could create duplicate expenses.

**Fix:** Added `_saving` boolean guard; button is blocked during the async save.

---

## Files Changed

| File | Change |
|---|---|
| `lib/core/config/supabase_config.dart` | dart-define injection |
| `lib/features/balances/screens/group_detail_screen.dart` | BUG-01, BUG-06 |
| `lib/features/expenses/providers/expenses_provider.dart` | BUG-03 |
| `lib/features/expenses/screens/add_expense_screen.dart` | BUG-02, BUG-03, double-submit |
| `lib/features/expenses/screens/add_expense_wizard.dart` | double-submit |
| `lib/features/groups/repositories/group_repository.dart` | BUG-05 |
| `lib/features/groups/screens/home_screen.dart` | BUG-06 |
| `lib/main.dart` | BUG-07 config guard |
| `.gitignore` | BUG-07 |

---

## How to build after this PR

```bash
flutter run \
  --dart-define=SUPABASE_URL=https://api.devsalah.com \
  --dart-define=SUPABASE_ANON_KEY=<your-anon-key>
```

---

## Still needed before Beta (not in this PR)
- BUG-04: Expense comments sync to Supabase (local-only today)
- CONFLICT-01: Basic conflict detection via updated_at
- Error handling in pushPendingChanges (partial sync recovery)
- deleteGroup Supabase cascade verification

See full review in `/tmp/split-review/REVIEW_DEV.md`.