### PR TITLE
feat: Comments sync to Supabase

### DIFF
--- a/lib/core/database/supabase_data_source.dart
+++ b/lib/core/database/supabase_data_source.dart
@@ -79,4 +79,30 @@ class SupabaseDataSource {
     debugPrint('[API] RPC $functionName: ${sw.elapsedMilliseconds}ms');
     return result as T;
   }
+
+  /// Sync a batch of comments to Supabase (upsert, last-write-wins for Beta).
+  Future<void> syncComments(List<Map<String, dynamic>> comments) async {
+    if (comments.isEmpty) return;
+    final sw = Stopwatch()..start();
+    // Strip sync_status — Supabase table does not have that column
+    final rows = comments.map((c) {
+      final m = Map<String, dynamic>.from(c);
+      m.remove('sync_status');
+      return m;
+    }).toList();
+    await _client.from('expense_comments').upsert(rows);
+    debugPrint('[API] syncComments (${rows.length} rows): ${sw.elapsedMilliseconds}ms');
+  }
+
+  /// Fetch comments for a given expense from Supabase.
+  Future<List<Map<String, dynamic>>> fetchComments(String expenseId) async {
+    final sw = Stopwatch()..start();
+    final result = await _client
+        .from('expense_comments')
+        .select()
+        .eq('expense_id', expenseId)
+        .order('created_at', ascending: true);
+    debugPrint('[API] fetchComments expense=$expenseId: ${sw.elapsedMilliseconds}ms, ${result.length} rows');
+    return result.cast<Map<String, dynamic>>();
+  }
 }

--- a/lib/core/sync/sync_service.dart
+++ b/lib/core/sync/sync_service.dart
@@ -128,6 +128,21 @@ class SyncService {
         }
       }
 
+      // Push pending comments (last-write-wins for Beta)
+      final pendingComments = await db.query('expense_comments', where: "sync_status = 'pending'");
+      if (pendingComments.isNotEmpty) {
+        try {
+          await _api.syncComments(pendingComments.map((c) => Map<String, dynamic>.from(c)).toList());
+          for (final c in pendingComments) {
+            await db.update('expense_comments', {'sync_status': 'synced'}, where: 'id = ?', whereArgs: [c['id']]);
+          }
+          debugPrint('[SYNC] pushed ${pendingComments.length} pending comment(s)');
+        } catch (e) {
+          // Non-fatal: comments stay pending and will retry on next sync
+          debugPrint('[SYNC] pushPendingComments error (will retry): $e');
+        }
+      }
+
       _setState(SyncState.idle);
       debugPrint('[SYNC] pushPendingChanges done');
     } catch (e) {
@@ -235,6 +250,14 @@ class SyncService {
           column: 'group_id',
           value: groupId,
         ),
+        callback: (_) => _debouncedNotify(groupId),
+      )
+      ..onPostgresChanges(
+        event: PostgresChangeEvent.all,
+        schema: 'public',
+        table: 'expense_comments',
+        // expense_comments has no group_id; notify on any expense change in this group
+        // (re-uses the same channel — coarse but sufficient for Beta)
         callback: (_) => _debouncedNotify(groupId),
       )
       ..subscribe();

--- a/lib/features/expenses/repositories/expense_repository.dart
+++ b/lib/features/expenses/repositories/expense_repository.dart
@@ -6,6 +6,7 @@ import '../../../core/database/database_helper.dart';
 import '../../../core/database/supabase_data_source.dart';
 import '../../../core/services/connectivity_service.dart';
 import '../models/expense.dart';
+import '../models/expense_comment.dart';
 
 class ExpenseRepository with ApiFirstRepository {
   ExpenseRepository({DatabaseHelper? db, SupabaseDataSource? api, ConnectivityService? connectivity}) {
@@ -246,6 +247,59 @@ class ExpenseRepository with ApiFirstRepository {
         ''', [groupId]);
         return maps.map((map) => ExpenseSplit.fromMap(map)).toList();
       },
+    );
+  }
+
+  // ── Comments ──────────────────────────────────────────────────────────────
+
+  /// Load comments for an expense: API-first, cache to SQLite, fallback offline.
+  Future<List<ExpenseComment>> getCommentsByExpense(String expenseId) async {
+    return fetchAndCache(
+      apiCall: () => api.fetchComments(expenseId),
+      cacheWriter: (database, rows) async {
+        final batch = database.batch();
+        for (final row in rows) {
+          batch.insert(
+            'expense_comments',
+            {
+              'id': row['id'],
+              'expense_id': row['expense_id'],
+              'member_name': row['member_name'],
+              'content': row['content'],
+              'created_at': row['created_at'],
+              'sync_status': 'synced',
+            },
+            conflictAlgorithm: ConflictAlgorithm.replace,
+          );
+        }
+        await batch.commit(noResult: true);
+      },
+      sqliteCall: () async {
+        final database = await db.database;
+        final maps = await database.query(
+          'expense_comments',
+          where: 'expense_id = ?',
+          whereArgs: [expenseId],
+          orderBy: 'created_at ASC',
+        );
+        return maps.map((m) => ExpenseComment.fromMap(m)).toList();
+      },
+    );
+  }
+
+  /// Add a comment with offline-first write-through.
+  Future<void> addComment(ExpenseComment comment) async {
+    await writeThrough(
+      apiCall: () => api.syncComments([comment.toMap()]),
+      sqliteCall: (database) async {
+        await database.insert(
+          'expense_comments',
+          comment.toMap(),
+          conflictAlgorithm: ConflictAlgorithm.replace,
+        );
+      },
+      syncTable: 'expense_comments',
+      syncId: comment.id,
     );
   }
 


### PR DESCRIPTION
## Summary
Comments now sync to the cloud via Supabase. Offline-first behavior is fully preserved.

## Changes
- **SupabaseDataSource**: Added `syncComments()` (batch upsert, strips `sync_status`) and `fetchComments(expenseId)`
- **ExpenseRepository**: Added `getCommentsByExpense()` (API-first with SQLite cache + offline fallback) and `addComment()` (write-through)
- **SyncService**: `pushPendingChanges()` now flushes pending comments when connectivity is restored — non-fatal error handling (retries on next sync)
- **SyncService**: `listenToGroup()` now subscribes to `expense_comments` realtime changes

## Conflict Strategy
Last-write-wins (upsert by PK). Sufficient for Beta — can revisit for v1.

## Testing
- Offline: comment is saved locally with `sync_status='pending'`; pushed on next reconnect
- Online: comment written to Supabase + cached in SQLite in one write-through call
- Realtime: other group members see new comments without manual refresh

Closes partial #11