### PR TITLE
fix: Integer cent arithmetic (no more floating point errors)

### DIFF
--- a/lib/core/database/database_helper.dart
+++ b/lib/core/database/database_helper.dart
@@ -21,7 +21,7 @@ class DatabaseHelper {
 
     return await openDatabase(
       path,
-      version: 8,
+      version: 9,
       onCreate: _onCreate,
       onUpgrade: _onUpgrade,
       onConfigure: (db) async {
@@ -61,6 +61,7 @@ class DatabaseHelper {
         id TEXT PRIMARY KEY,
         description TEXT NOT NULL,
         amount REAL NOT NULL,
+        amount_cents INTEGER NOT NULL DEFAULT 0,
         paid_by_id TEXT NOT NULL,
         group_id TEXT NOT NULL,
         created_at TEXT NOT NULL,
@@ -81,6 +82,7 @@ class DatabaseHelper {
         expense_id TEXT NOT NULL,
         member_id TEXT NOT NULL,
         amount REAL NOT NULL,
+        amount_cents INTEGER NOT NULL DEFAULT 0,
         FOREIGN KEY (expense_id) REFERENCES expenses(id) ON DELETE CASCADE,
         FOREIGN KEY (member_id) REFERENCES members(id) ON DELETE CASCADE
       )
@@ -92,6 +94,7 @@ class DatabaseHelper {
         expense_id TEXT NOT NULL,
         member_id TEXT NOT NULL,
         amount REAL NOT NULL,
+        amount_cents INTEGER NOT NULL DEFAULT 0,
         FOREIGN KEY (expense_id) REFERENCES expenses(id) ON DELETE CASCADE,
         FOREIGN KEY (member_id) REFERENCES members(id) ON DELETE CASCADE
       )
@@ -255,6 +258,17 @@ class DatabaseHelper {
       await db.execute('CREATE INDEX IF NOT EXISTS idx_expense_comments_expense_id ON expense_comments(expense_id)');
       // Backfill expense_date from created_at for existing rows
       await db.execute('UPDATE expenses SET expense_date = created_at WHERE expense_date IS NULL');
+    }
+    if (oldVersion < 9) {
+      // Add integer cent columns; backfill from existing float columns.
+      await db.execute('ALTER TABLE expenses ADD COLUMN amount_cents INTEGER NOT NULL DEFAULT 0');
+      await db.execute('UPDATE expenses SET amount_cents = CAST(ROUND(amount * 100) AS INTEGER)');
+
+      await db.execute('ALTER TABLE expense_splits ADD COLUMN amount_cents INTEGER NOT NULL DEFAULT 0');
+      await db.execute('UPDATE expense_splits SET amount_cents = CAST(ROUND(amount * 100) AS INTEGER)');
+
+      await db.execute('ALTER TABLE expense_payers ADD COLUMN amount_cents INTEGER NOT NULL DEFAULT 0');
+      await db.execute('UPDATE expense_payers SET amount_cents = CAST(ROUND(amount * 100) AS INTEGER)');
     }
   }
 }

--- a/lib/features/balances/models/balance.dart
+++ b/lib/features/balances/models/balance.dart
@@ -1,23 +1,33 @@
 import '../../members/models/member.dart';
 
+/// A suggested settlement between two members.
+/// [amountCents] is the amount in integer cents; use [amount] only for display.
 class Settlement {
   final Member fromMember;
   final Member toMember;
-  final double amount;
+  final int amountCents;
+
+  /// Convenience getter for display.
+  double get amount => amountCents / 100;
 
   Settlement({
     required this.fromMember,
     required this.toMember,
-    required this.amount,
+    required this.amountCents,
   });
 }
 
+/// A member's net balance in integer cents.
+/// Positive = is owed money; negative = owes money.
 class MemberBalance {
   final Member member;
-  final double netBalance;
+  final int netBalanceCents;
+
+  /// Convenience getter for display.
+  double get netBalance => netBalanceCents / 100;
 
   MemberBalance({
     required this.member,
-    required this.netBalance,
+    required this.netBalanceCents,
   });
 }

--- a/lib/features/balances/providers/balances_provider.dart
+++ b/lib/features/balances/providers/balances_provider.dart
@@ -70,7 +70,7 @@ final groupComputedDataProvider =
   );
   debugPrint('[PERF]   DebtCalculator: ${sw.elapsedMilliseconds}ms');
 
-  final totalSpend = expenses.fold(0.0, (sum, e) => sum + e.amount);
+  final totalSpend = expenses.fold(0, (sum, e) => sum + e.amountCents) / 100.0;
   final memberMap = {for (var m in members) m.id: m.name};
 
   debugPrint('[PERF] groupComputedDataProvider($groupId) DONE in ${swTotal.elapsedMilliseconds}ms');

--- a/lib/features/balances/services/debt_calculator.dart
+++ b/lib/features/balances/services/debt_calculator.dart
@@ -4,7 +4,8 @@ import '../../settlements/models/settlement_record.dart';
 import '../models/balance.dart';
 
 class DebtCalculator {
-  static const _epsilon = 0.01;
+  /// Minimum meaningful amount: 1 cent.
+  static const _epsilonCents = 1;
 
   static List<MemberBalance> calculateNetBalances(
     List<Member> members,
@@ -13,9 +14,10 @@ class DebtCalculator {
     List<SettlementRecord> settlements = const [],
     List<ExpensePayer> payers = const [],
   }) {
-    final balances = <String, double>{};
+    // All arithmetic in integer cents — no floating-point accumulation errors.
+    final balances = <String, int>{};
     for (final member in members) {
-      balances[member.id] = 0.0;
+      balances[member.id] = 0;
     }
 
     // Build a map of expense_id -> list of payers for multi-payer lookup
@@ -24,40 +26,39 @@ class DebtCalculator {
       payersByExpense.putIfAbsent(payer.expenseId, () => []).add(payer);
     }
 
-    // Add what each member paid
+    // Add what each member paid (in cents)
     for (final expense in expenses) {
       final expensePayers = payersByExpense[expense.id];
       if (expensePayers != null && expensePayers.isNotEmpty) {
-        // Multi-payer: use the payer records
         for (final payer in expensePayers) {
           balances[payer.memberId] =
-              (balances[payer.memberId] ?? 0) + payer.amount;
+              (balances[payer.memberId] ?? 0) + payer.amountCents;
         }
       } else {
-        // Backward compatibility: single payer from expense.paidById
+        // Backward compat: single payer from expense.paidById
         balances[expense.paidById] =
-            (balances[expense.paidById] ?? 0) + expense.amount;
+            (balances[expense.paidById] ?? 0) + expense.amountCents;
       }
     }
 
-    // Subtract what each member owes
+    // Subtract what each member owes (in cents)
     for (final split in splits) {
       balances[split.memberId] =
-          (balances[split.memberId] ?? 0) - split.amount;
+          (balances[split.memberId] ?? 0) - split.amountCents;
     }
 
-    // Apply settlements: fromMember paid toMember
+    // Apply settlements: fromMember paid toMember (in cents)
     for (final s in settlements) {
       balances[s.fromMemberId] =
-          (balances[s.fromMemberId] ?? 0) + s.amount;
+          (balances[s.fromMemberId] ?? 0) + s.amountCents;
       balances[s.toMemberId] =
-          (balances[s.toMemberId] ?? 0) - s.amount;
+          (balances[s.toMemberId] ?? 0) - s.amountCents;
     }
 
     return members.map((member) {
       return MemberBalance(
         member: member,
-        netBalance: balances[member.id] ?? 0.0,
+        netBalanceCents: balances[member.id] ?? 0,
       );
     }).toList();
   }
@@ -70,7 +71,8 @@ class DebtCalculator {
     List<ExpensePayer> payers = const [],
   }) {
     final netBalances = calculateNetBalances(
-      members, expenses, splits, settlements: settlements, payers: payers,
+      members, expenses, splits,
+      settlements: settlements, payers: payers,
     );
     final result = <Settlement>[];
 
@@ -78,35 +80,35 @@ class DebtCalculator {
     final debtors = <_BalanceEntry>[];
 
     for (final mb in netBalances) {
-      if (mb.netBalance > _epsilon) {
-        creditors.add(_BalanceEntry(member: mb.member, amount: mb.netBalance));
-      } else if (mb.netBalance < -_epsilon) {
-        debtors.add(_BalanceEntry(member: mb.member, amount: -mb.netBalance));
+      if (mb.netBalanceCents > _epsilonCents) {
+        creditors.add(_BalanceEntry(member: mb.member, amountCents: mb.netBalanceCents));
+      } else if (mb.netBalanceCents < -_epsilonCents) {
+        debtors.add(_BalanceEntry(member: mb.member, amountCents: -mb.netBalanceCents));
       }
     }
 
-    creditors.sort((a, b) => b.amount.compareTo(a.amount));
-    debtors.sort((a, b) => b.amount.compareTo(a.amount));
+    creditors.sort((a, b) => b.amountCents.compareTo(a.amountCents));
+    debtors.sort((a, b) => b.amountCents.compareTo(a.amountCents));
 
     int ci = 0, di = 0;
     while (ci < creditors.length && di < debtors.length) {
-      final transfer = creditors[ci].amount < debtors[di].amount
-          ? creditors[ci].amount
-          : debtors[di].amount;
+      final transfer = creditors[ci].amountCents < debtors[di].amountCents
+          ? creditors[ci].amountCents
+          : debtors[di].amountCents;
 
-      if (transfer > _epsilon) {
+      if (transfer >= _epsilonCents) {
         result.add(Settlement(
           fromMember: debtors[di].member,
           toMember: creditors[ci].member,
-          amount: (transfer * 100).roundToDouble() / 100,
+          amountCents: transfer,
         ));
       }
 
-      creditors[ci].amount -= transfer;
-      debtors[di].amount -= transfer;
+      creditors[ci].amountCents -= transfer;
+      debtors[di].amountCents -= transfer;
 
-      if (creditors[ci].amount < _epsilon) ci++;
-      if (debtors[di].amount < _epsilon) di++;
+      if (creditors[ci].amountCents < _epsilonCents) ci++;
+      if (debtors[di].amountCents < _epsilonCents) di++;
     }
 
     return result;
@@ -115,7 +117,7 @@ class DebtCalculator {
 
 class _BalanceEntry {
   final Member member;
-  double amount;
+  int amountCents;
 
-  _BalanceEntry({required this.member, required this.amount});
+  _BalanceEntry({required this.member, required this.amountCents});
 }

--- a/lib/features/expenses/models/expense.dart
+++ b/lib/features/expenses/models/expense.dart
@@ -1,7 +1,7 @@
 class Expense {
   final String id;
   final String description;
-  final double amount;
+  final int amountCents;
   final String paidById;
   final String groupId;
   final DateTime createdAt;
@@ -12,10 +12,13 @@ class Expense {
   final DateTime? updatedAt;
   final String syncStatus;
 
+  /// Convenience getter for display – do NOT use in arithmetic.
+  double get amount => amountCents / 100;
+
   Expense({
     required this.id,
     required this.description,
-    required this.amount,
+    required this.amountCents,
     required this.paidById,
     required this.groupId,
     required this.createdAt,
@@ -31,7 +34,9 @@ class Expense {
     return {
       'id': id,
       'description': description,
-      'amount': amount,
+      'amount_cents': amountCents,
+      // Keep legacy `amount` column populated so old DB versions can still read.
+      'amount': amountCents / 100.0,
       'paid_by_id': paidById,
       'group_id': groupId,
       'created_at': createdAt.toIso8601String(),
@@ -47,15 +52,22 @@ class Expense {
   Map<String, dynamic> toApiMap() {
     final map = toMap();
     map.remove('sync_status');
+    map.remove('amount_cents'); // API still uses `amount` (float)
     return map;
   }
 
   factory Expense.fromMap(Map<String, dynamic> map) {
     final createdAt = DateTime.parse(map['created_at'] as String);
+    final int cents;
+    if (map['amount_cents'] != null) {
+      cents = (map['amount_cents'] as num).toInt();
+    } else {
+      cents = ((map['amount'] as num).toDouble() * 100).round();
+    }
     return Expense(
       id: map['id'] as String,
       description: map['description'] as String,
-      amount: (map['amount'] as num).toDouble(),
+      amountCents: cents,
       paidById: map['paid_by_id'] as String,
       groupId: map['group_id'] as String,
       createdAt: createdAt,
@@ -77,13 +89,16 @@ class ExpensePayer {
   final String id;
   final String expenseId;
   final String memberId;
-  final double amount;
+  final int amountCents;
+
+  /// Convenience getter for display – do NOT use in arithmetic.
+  double get amount => amountCents / 100;
 
   ExpensePayer({
     required this.id,
     required this.expenseId,
     required this.memberId,
-    required this.amount,
+    required this.amountCents,
   });
 
   Map<String, dynamic> toMap() {
@@ -91,16 +106,23 @@ class ExpensePayer {
       'id': id,
       'expense_id': expenseId,
       'member_id': memberId,
-      'amount': amount,
+      'amount_cents': amountCents,
+      'amount': amountCents / 100.0,
     };
   }
 
   factory ExpensePayer.fromMap(Map<String, dynamic> map) {
+    final int cents;
+    if (map['amount_cents'] != null) {
+      cents = (map['amount_cents'] as num).toInt();
+    } else {
+      cents = ((map['amount'] as num).toDouble() * 100).round();
+    }
     return ExpensePayer(
       id: map['id'] as String,
       expenseId: map['expense_id'] as String,
       memberId: map['member_id'] as String,
-      amount: (map['amount'] as num).toDouble(),
+      amountCents: cents,
     );
   }
 }
@@ -109,13 +131,16 @@ class ExpenseSplit {
   final String id;
   final String expenseId;
   final String memberId;
-  final double amount;
+  final int amountCents;
+
+  /// Convenience getter for display – do NOT use in arithmetic.
+  double get amount => amountCents / 100;
 
   ExpenseSplit({
     required this.id,
     required this.expenseId,
     required this.memberId,
-    required this.amount,
+    required this.amountCents,
   });
 
   Map<String, dynamic> toMap() {
@@ -123,16 +148,23 @@ class ExpenseSplit {
       'id': id,
       'expense_id': expenseId,
       'member_id': memberId,
-      'amount': amount,
+      'amount_cents': amountCents,
+      'amount': amountCents / 100.0,
     };
   }
 
   factory ExpenseSplit.fromMap(Map<String, dynamic> map) {
+    final int cents;
+    if (map['amount_cents'] != null) {
+      cents = (map['amount_cents'] as num).toInt();
+    } else {
+      cents = ((map['amount'] as num).toDouble() * 100).round();
+    }
     return ExpenseSplit(
       id: map['id'] as String,
       expenseId: map['expense_id'] as String,
       memberId: map['member_id'] as String,
-      amount: (map['amount'] as num).toDouble(),
+      amountCents: cents,
     );
   }
 }

--- a/lib/features/expenses/providers/expenses_provider.dart
+++ b/lib/features/expenses/providers/expenses_provider.dart
@@ -43,13 +43,15 @@ class ExpensesNotifier extends FamilyAsyncNotifier<List<Expense>, String> {
     }
 
     final expenseId = const Uuid().v4();
-    final perPayerAmount = amount / paidByIds.length;
+    // Convert to cents once; all arithmetic in int from here on.
+    final totalCents = (amount * 100).round();
+    final perPayerCents = totalCents ~/ paidByIds.length;
     final now = DateTime.now();
 
     final expense = Expense(
       id: expenseId,
       description: description,
-      amount: amount,
+      amountCents: totalCents,
       paidById: paidByIds.first,
       groupId: arg,
       createdAt: now,
@@ -60,12 +62,14 @@ class ExpensesNotifier extends FamilyAsyncNotifier<List<Expense>, String> {
     );
 
     final splits = splitAmongIds.map((memberId) {
-      final splitAmount = customSplits?[memberId] ?? amount / splitAmongIds.length;
+      final int splitCents = customSplits != null && customSplits[memberId] != null
+          ? (customSplits[memberId]! * 100).round()
+          : totalCents ~/ splitAmongIds.length;
       return ExpenseSplit(
         id: const Uuid().v4(),
         expenseId: expenseId,
         memberId: memberId,
-        amount: splitAmount,
+        amountCents: splitCents,
       );
     }).toList();
 
@@ -74,7 +78,7 @@ class ExpensesNotifier extends FamilyAsyncNotifier<List<Expense>, String> {
         id: const Uuid().v4(),
         expenseId: expenseId,
         memberId: memberId,
-        amount: perPayerAmount,
+        amountCents: perPayerCents,
       );
     }).toList();
 
@@ -103,7 +107,9 @@ class ExpensesNotifier extends FamilyAsyncNotifier<List<Expense>, String> {
       throw ArgumentError('At least one payer must be selected');
     }
 
-    final perPayerAmount = amount / paidByIds.length;
+    // Convert to cents once; all arithmetic in int from here on.
+    final totalCents = (amount * 100).round();
+    final perPayerCents = totalCents ~/ paidByIds.length;
 
     final now = DateTime.now();
     // Preserve the original createdAt — do NOT use DateTime.now() which would
@@ -112,7 +118,7 @@ class ExpensesNotifier extends FamilyAsyncNotifier<List<Expense>, String> {
     final expense = Expense(
       id: expenseId,
       description: description,
-      amount: amount,
+      amountCents: totalCents,
       paidById: paidByIds.first,
       groupId: arg,
       createdAt: createdAt,
@@ -124,13 +130,14 @@ class ExpensesNotifier extends FamilyAsyncNotifier<List<Expense>, String> {
     );
 
     final splits = splitAmongIds.map((memberId) {
-      final splitAmount =
-          customSplits?[memberId] ?? amount / splitAmongIds.length;
+      final int splitCents = customSplits != null && customSplits[memberId] != null
+          ? (customSplits[memberId]! * 100).round()
+          : totalCents ~/ splitAmongIds.length;
       return ExpenseSplit(
         id: const Uuid().v4(),
         expenseId: expenseId,
         memberId: memberId,
-        amount: splitAmount,
+        amountCents: splitCents,
       );
     }).toList();
 
@@ -139,7 +146,7 @@ class ExpensesNotifier extends FamilyAsyncNotifier<List<Expense>, String> {
         id: const Uuid().v4(),
         expenseId: expenseId,
         memberId: memberId,
-        amount: perPayerAmount,
+        amountCents: perPayerCents,
       );
     }).toList();
 

--- a/lib/features/expenses/repositories/expense_repository.dart
+++ b/lib/features/expenses/repositories/expense_repository.dart
@@ -21,12 +21,15 @@ class ExpenseRepository with ApiFirstRepository {
       cacheWriter: (database, rows) async {
         final batch = database.batch();
         for (final row in rows) {
+          final double rawAmount = (row['amount'] as num?)?.toDouble() ?? 0.0;
+          final int cents = (rawAmount * 100).round();
           batch.insert(
             'expenses',
             {
               'id': row['id'],
               'description': row['description'],
-              'amount': row['amount'],
+              'amount': rawAmount,
+              'amount_cents': cents,
               'paid_by_id': row['paid_by_id'],
               'group_id': row['group_id'],
               'created_at': row['created_at'],
@@ -120,13 +123,15 @@ class ExpenseRepository with ApiFirstRepository {
       cacheWriter: (database, rows) async {
         final batch = database.batch();
         for (final row in rows) {
+          final double rawAmount = (row['amount'] as num?)?.toDouble() ?? 0.0;
           batch.insert(
             'expense_splits',
             {
               'id': row['id'],
               'expense_id': row['expense_id'],
               'member_id': row['member_id'],
-              'amount': row['amount'],
+              'amount': rawAmount,
+              'amount_cents': (rawAmount * 100).round(),
             },
             conflictAlgorithm: ConflictAlgorithm.replace,
           );
@@ -148,13 +153,15 @@ class ExpenseRepository with ApiFirstRepository {
       cacheWriter: (database, rows) async {
         final batch = database.batch();
         for (final row in rows) {
+          final double rawAmount = (row['amount'] as num?)?.toDouble() ?? 0.0;
           batch.insert(
             'expense_payers',
             {
               'id': row['id'],
               'expense_id': row['expense_id'],
               'member_id': row['member_id'],
-              'amount': row['amount'],
+              'amount': rawAmount,
+              'amount_cents': (rawAmount * 100).round(),
             },
             conflictAlgorithm: ConflictAlgorithm.replace,
           );
@@ -179,13 +186,15 @@ class ExpenseRepository with ApiFirstRepository {
       cacheWriter: (database, rows) async {
         final batch = database.batch();
         for (final row in rows) {
+          final double rawAmount = (row['amount'] as num?)?.toDouble() ?? 0.0;
           batch.insert(
             'expense_payers',
             {
               'id': row['id'],
               'expense_id': row['expense_id'],
               'member_id': row['member_id'],
-              'amount': row['amount'],
+              'amount': rawAmount,
+              'amount_cents': (rawAmount * 100).round(),
             },
             conflictAlgorithm: ConflictAlgorithm.replace,
           );
@@ -213,13 +222,15 @@ class ExpenseRepository with ApiFirstRepository {
       cacheWriter: (database, rows) async {
         final batch = database.batch();
         for (final row in rows) {
+          final double rawAmount = (row['amount'] as num?)?.toDouble() ?? 0.0;
           batch.insert(
             'expense_splits',
             {
               'id': row['id'],
               'expense_id': row['expense_id'],
               'member_id': row['member_id'],
-              'amount': row['amount'],
+              'amount': rawAmount,
+              'amount_cents': (rawAmount * 100).round(),
             },
             conflictAlgorithm: ConflictAlgorithm.replace,
           );

--- a/lib/features/settlements/models/settlement_record.dart
+++ b/lib/features/settlements/models/settlement_record.dart
@@ -3,19 +3,22 @@ class SettlementRecord {
   final String groupId;
   final String fromMemberId;
   final String toMemberId;
-  final double amount;
+  final int amountCents;
   final DateTime createdAt;
   final String? fromMemberName;
   final String? toMemberName;
   final DateTime? updatedAt;
   final String syncStatus;
 
+  /// Convenience getter for display.
+  double get amount => amountCents / 100;
+
   SettlementRecord({
     required this.id,
     required this.groupId,
     required this.fromMemberId,
     required this.toMemberId,
-    required this.amount,
+    required this.amountCents,
     required this.createdAt,
     this.fromMemberName,
     this.toMemberName,
@@ -29,10 +32,10 @@ class SettlementRecord {
       'group_id': groupId,
       'from_member_id': fromMemberId,
       'to_member_id': toMemberId,
-      'amount': amount,
-      'created_at': createdAt.toIso8601String(),
+      'amount': amountCents / 100.0,
       'from_member_name': fromMemberName,
       'to_member_name': toMemberName,
+      'created_at': createdAt.toIso8601String(),
       'updated_at': (updatedAt ?? DateTime.now()).toIso8601String(),
       'sync_status': syncStatus,
     };
@@ -45,12 +48,18 @@ class SettlementRecord {
   }
 
   factory SettlementRecord.fromMap(Map<String, dynamic> map) {
+    final int cents;
+    if (map['amount_cents'] != null) {
+      cents = (map['amount_cents'] as num).toInt();
+    } else {
+      cents = ((map['amount'] as num).toDouble() * 100).round();
+    }
     return SettlementRecord(
       id: map['id'] as String,
       groupId: map['group_id'] as String,
       fromMemberId: map['from_member_id'] as String,
       toMemberId: map['to_member_id'] as String,
-      amount: (map['amount'] as num).toDouble(),
+      amountCents: cents,
       createdAt: DateTime.parse(map['created_at'] as String),
       fromMemberName: map['from_member_name'] as String?,
       toMemberName: map['to_member_name'] as String?,

--- a/lib/features/settlements/providers/settlements_provider.dart
+++ b/lib/features/settlements/providers/settlements_provider.dart
@@ -35,7 +35,7 @@ class SettlementRecordsNotifier
       groupId: arg,
       fromMemberId: fromMemberId,
       toMemberId: toMemberId,
-      amount: amount,
+      amountCents: (amount * 100).round(),
       createdAt: DateTime.now(),
       fromMemberName: fromMemberName,
       toMemberName: toMemberName,


### PR DESCRIPTION
Closes #16. Fixes accumulating rounding errors in expense calculations.

## Changes
- `Expense`, `ExpenseSplit`, `ExpensePayer`: `amount` (double) → `amountCents` (int) with backward-compat display getter
- `MemberBalance`: `netBalance` (double) → `netBalanceCents` (int) with display getter
- `Settlement`: `amount` (double) → `amountCents` (int) with display getter
- `DebtCalculator`: all arithmetic in integer cents, epsilon = 1 cent (no more 0.01 float epsilon)
- `DatabaseHelper`: DB v9 migration adds `amount_cents` columns, backfills from `ROUND(amount * 100)`
- `ExpenseRepository`: reads/writes `amount_cents`; `fromMap` falls back to legacy `amount` column for old data
- UI screens: unchanged — they use `.amount` display getters, no breaking changes