### PR TITLE
fix: Anonymous auth persists across app restarts

### DIFF
--- a/lib/core/services/auth_service.dart
+++ b/lib/core/services/auth_service.dart
@@ -1,9 +1,26 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+/// Handles anonymous authentication with persistence across app restarts.
+///
+/// Strategy:
+/// 1. On first login, save the Supabase user-id and refresh-token to
+///    FlutterSecureStorage.
+/// 2. On subsequent launches, restore the session from the stored tokens
+///    (Supabase handles this automatically via [recoverSession]).
+/// 3. If no stored session is found, sign in anonymously and persist the
+///    new session.
 class AuthService {
   static final AuthService instance = AuthService._();
   AuthService._();
+
+  static const _storage = FlutterSecureStorage(
+    aOptions: AndroidOptions(encryptedSharedPreferences: true),
+  );
+  static const _keyUserId = 'anon_user_id';
+  static const _keyAccessToken = 'anon_access_token';
+  static const _keyRefreshToken = 'anon_refresh_token';
 
   bool _initialized = false;
 
@@ -17,17 +34,72 @@ class AuthService {
     return Supabase.instance.client.auth.currentUser != null;
   }
 
+  /// Call once at app startup. Restores a persisted session when possible,
+  /// otherwise signs in anonymously and persists the new session.
   Future<void> signInAnonymously() async {
     try {
       final auth = Supabase.instance.client.auth;
+
+      // 1. Already have an active in-memory session (e.g. hot restart).
       if (auth.currentUser != null) {
         _initialized = true;
         return;
       }
-      await auth.signInAnonymously();
+
+      // 2. Try to restore from SecureStorage.
+      final storedRefreshToken = await _storage.read(key: _keyRefreshToken);
+      final storedAccessToken = await _storage.read(key: _keyAccessToken);
+
+      if (storedRefreshToken != null && storedAccessToken != null) {
+        try {
+          final response = await auth.setSession(storedAccessToken);
+          if (response.user != null) {
+            debugPrint('[Auth] Session restored for user: ${response.user!.id}');
+            _initialized = true;
+            // Persist the refreshed tokens.
+            await _persistSession(response.session!);
+            return;
+          }
+        } catch (e) {
+          // Stored session is invalid or expired — fall through to re-auth.
+          debugPrint('[Auth] Stored session invalid, re-authenticating: $e');
+          await _clearStoredSession();
+        }
+      }
+
+      // 3. No valid session — sign in anonymously and persist.
+      final response = await auth.signInAnonymously();
+      if (response.user != null && response.session != null) {
+        debugPrint('[Auth] Signed in anonymously as: ${response.user!.id}');
+        await _persistSession(response.session!);
+      }
       _initialized = true;
     } catch (e) {
-      debugPrint('Auth error: $e');
+      debugPrint('[Auth] Error during signInAnonymously: $e');
     }
+  }
+
+  Future<void> _persistSession(Session session) async {
+    await Future.wait([
+      _storage.write(key: _keyUserId, value: session.user.id),
+      _storage.write(key: _keyAccessToken, value: session.accessToken),
+      _storage.write(key: _keyRefreshToken, value: session.refreshToken ?? ''),
+    ]);
+    debugPrint('[Auth] Session persisted for user: ${session.user.id}');
+  }
+
+  Future<void> _clearStoredSession() async {
+    await Future.wait([
+      _storage.delete(key: _keyUserId),
+      _storage.delete(key: _keyAccessToken),
+      _storage.delete(key: _keyRefreshToken),
+    ]);
+  }
+
+  /// Sign out and clear the persisted session.
+  Future<void> signOut() async {
+    await Supabase.instance.client.auth.signOut();
+    await _clearStoredSession();
+    _initialized = false;
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   app_links: ^6.3.0
   connectivity_plus: ^6.1.0
   shared_preferences: ^2.3.4
+  flutter_secure_storage: ^9.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Fixes anonymous user getting a new ID every time the app relaunches.

## Problem
`signInAnonymously()` was called unconditionally on startup, creating a new anonymous user each launch if the in-memory session was gone (cold start). This meant users lost their groups after killing the app.

## Solution
- Added `flutter_secure_storage` to store Supabase access + refresh tokens securely
- On startup: restore session from stored tokens via `auth.setSession()`
- Falls back to fresh anonymous sign-in only if no stored session or it expired
- Tokens are updated after each restore to stay fresh

## Testing
1. Sign in (anon) — note user ID
2. Kill app completely
3. Reopen — same user ID should be used, groups still visible