### PR TITLE
fix: Multi-currency balance calculation (Issue #22)

### DIFF
--- a/lib/core/utils/currency_utils.dart
+++ b/lib/core/utils/currency_utils.dart
@@ -1,19 +1,34 @@
 const currencySymbols = <String, String>{
   'USD': '\$',
-  'EUR': '\u20AC',
-  'GBP': '\u00A3',
-  'JPY': '\u00A5',
+  'EUR': '€',
+  'GBP': '£',
+  'JPY': '¥',
   'CAD': 'CA\$',
   'AUD': 'A\$',
   'CHF': 'CHF',
-  'CNY': '\u00A5',
-  'INR': '\u20B9',
+  'CNY': '¥',
+  'INR': '₹',
   'MXN': 'MX\$',
+  'BRL': 'R\$',
+  'SEK': 'kr',
+  'NOK': 'kr',
+  'DKK': 'kr',
+  'PLN': 'zł',
+  'CZK': 'Kč',
+  'HUF': 'Ft',
+  'RON': 'lei',
+  'TRY': '₺',
+  'RUB': '₽',
+  'KRW': '₩',
+  'SGD': 'S\$',
+  'HKD': 'HK\$',
+  'NZD': 'NZ\$',
+  'ZAR': 'R',
 };
 
 String formatCurrency(double amount, [String currency = 'USD']) {
   final symbol = currencySymbols[currency] ?? currency;
-  if (currency == 'JPY') {
+  if (currency == 'JPY' || currency == 'KRW' || currency == 'HUF') {
     return '$symbol${amount.round()}';
   }
   return '$symbol${amount.toStringAsFixed(2)}';
@@ -21,4 +36,70 @@ String formatCurrency(double amount, [String currency = 'USD']) {
 
 String getCurrencySymbol(String currency) {
   return currencySymbols[currency] ?? currency;
+}
+
+/// Currency converter using EUR as the base currency.
+/// TODO: live rates — replace static rates with an API call (e.g. ECB, Fixer.io)
+class CurrencyConverter {
+  CurrencyConverter._();
+
+  /// Exchange rates relative to EUR (1 EUR = X currency).
+  static const Map<String, double> _ratesFromEur = {
+    'EUR': 1.0,
+    'USD': 1.08,
+    'GBP': 0.86,
+    'JPY': 161.5,
+    'CAD': 1.47,
+    'AUD': 1.66,
+    'CHF': 0.97,
+    'CNY': 7.83,
+    'INR': 90.1,
+    'MXN': 18.4,
+    'BRL': 5.35,
+    'SEK': 11.3,
+    'NOK': 11.5,
+    'DKK': 7.46,
+    'PLN': 4.27,
+    'CZK': 25.3,
+    'HUF': 395.0,
+    'RON': 4.97,
+    'TRY': 35.0,
+    'RUB': 98.0,
+    'KRW': 1450.0,
+    'SGD': 1.46,
+    'HKD': 8.45,
+    'NZD': 1.80,
+    'ZAR': 20.2,
+  };
+
+  /// Convert [amountCents] from [fromCurrency] to EUR cents.
+  /// Returns amountCents unchanged if the currency is unknown (fail-open).
+  static int toEurCents(int amountCents, String fromCurrency) {
+    if (fromCurrency == 'EUR') return amountCents;
+    final rate = _ratesFromEur[fromCurrency];
+    if (rate == null || rate == 0) return amountCents; // unknown currency — pass through
+    return (amountCents / rate).round();
+  }
+
+  /// Convert [eurCents] from EUR to [toCurrency] cents.
+  static int fromEurCents(int eurCents, String toCurrency) {
+    if (toCurrency == 'EUR') return eurCents;
+    final rate = _ratesFromEur[toCurrency];
+    if (rate == null) return eurCents; // unknown currency — pass through
+    return (eurCents * rate).round();
+  }
+
+  /// Convert [amountCents] from [fromCurrency] to [toCurrency].
+  static int convert(int amountCents, String fromCurrency, String toCurrency) {
+    if (fromCurrency == toCurrency) return amountCents;
+    final eurCents = toEurCents(amountCents, fromCurrency);
+    return fromEurCents(eurCents, toCurrency);
+  }
+
+  /// Whether a currency code is known.
+  static bool isSupported(String currency) => _ratesFromEur.containsKey(currency);
+
+  /// Sorted list of supported currency codes.
+  static List<String> get supportedCurrencies =>
+      _ratesFromEur.keys.toList()..sort();
 }

--- a/lib/features/balances/providers/balances_provider.dart
+++ b/lib/features/balances/providers/balances_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../expenses/providers/expenses_provider.dart';
+import '../../groups/providers/groups_provider.dart';
 import '../../members/providers/members_provider.dart';
 import '../../settlements/models/settlement_record.dart';
 import '../../settlements/providers/settlements_provider.dart';
@@ -59,14 +60,26 @@ final groupComputedDataProvider =
   final members = membersResult;
   final expenses = expensesResult;
 
+  // Determine group display currency (balances always shown in group currency)
+  final groups = ref.read(groupsProvider).valueOrNull ?? [];
+  final group = groups.firstWhere(
+    (g) => g.id == groupId,
+    orElse: () => throw StateError('Group $groupId not found'),
+  );
+  final displayCurrency = group.currency;
+
   debugPrint('[PERF]   members=${members.length}, expenses=${expenses.length}, settlements=${settlementRecords.length}, splits=${splits.length}, payers=${payers.length}');
 
   var sw = Stopwatch()..start();
   final balances = DebtCalculator.calculateNetBalances(
-    members, expenses, splits, settlements: settlementRecords, payers: payers,
+    members, expenses, splits,
+    settlements: settlementRecords, payers: payers,
+    displayCurrency: displayCurrency,
   );
   final settlements = DebtCalculator.calculateSettlements(
-    members, expenses, splits, settlements: settlementRecords, payers: payers,
+    members, expenses, splits,
+    settlements: settlementRecords, payers: payers,
+    displayCurrency: displayCurrency,
   );
   debugPrint('[PERF]   DebtCalculator: ${sw.elapsedMilliseconds}ms');
 

--- a/lib/features/balances/services/debt_calculator.dart
+++ b/lib/features/balances/services/debt_calculator.dart
@@ -1,3 +1,4 @@
+import '../../../core/utils/currency_utils.dart';
 import '../../expenses/models/expense.dart';
 import '../../members/models/member.dart';
 import '../../settlements/models/settlement_record.dart';
@@ -7,18 +8,27 @@ class DebtCalculator {
   /// Minimum meaningful amount: 1 cent.
   static const _epsilonCents = 1;
 
+  /// All arithmetic is performed in EUR cents to avoid multi-currency addition
+  /// errors. Display conversion back to the group currency happens in the UI.
   static List<MemberBalance> calculateNetBalances(
     List<Member> members,
     List<Expense> expenses,
     List<ExpenseSplit> splits, {
     List<SettlementRecord> settlements = const [],
     List<ExpensePayer> payers = const [],
+    /// The currency in which to express the resulting balances (group currency).
+    String displayCurrency = 'EUR',
   }) {
-    // All arithmetic in integer cents — no floating-point accumulation errors.
+    // All arithmetic in integer EUR-cents — no floating-point accumulation errors.
     final balances = <String, int>{};
     for (final member in members) {
       balances[member.id] = 0;
     }
+
+    // Build a lookup of expense_id -> currency for multi-currency conversion
+    final expenseCurrency = <String, String>{
+      for (final e in expenses) e.id: e.currency,
+    };
 
     // Build a map of expense_id -> list of payers for multi-payer lookup
     final payersByExpense = <String, List<ExpensePayer>>{};
@@ -26,39 +36,44 @@ class DebtCalculator {
       payersByExpense.putIfAbsent(payer.expenseId, () => []).add(payer);
     }
 
-    // Add what each member paid (in cents)
+    // Add what each member paid — convert to EUR cents first
     for (final expense in expenses) {
+      final currency = expense.currency;
       final expensePayers = payersByExpense[expense.id];
       if (expensePayers != null && expensePayers.isNotEmpty) {
         for (final payer in expensePayers) {
-          balances[payer.memberId] =
-              (balances[payer.memberId] ?? 0) + payer.amountCents;
+          final eurCents = CurrencyConverter.toEurCents(payer.amountCents, currency);
+          balances[payer.memberId] = (balances[payer.memberId] ?? 0) + eurCents;
         }
       } else {
         // Backward compat: single payer from expense.paidById
-        balances[expense.paidById] =
-            (balances[expense.paidById] ?? 0) + expense.amountCents;
+        final eurCents = CurrencyConverter.toEurCents(expense.amountCents, currency);
+        balances[expense.paidById] = (balances[expense.paidById] ?? 0) + eurCents;
       }
     }
 
-    // Subtract what each member owes (in cents)
+    // Subtract what each member owes — splits inherit their expense's currency
     for (final split in splits) {
-      balances[split.memberId] =
-          (balances[split.memberId] ?? 0) - split.amountCents;
+      final currency = expenseCurrency[split.expenseId] ?? 'EUR';
+      final eurCents = CurrencyConverter.toEurCents(split.amountCents, currency);
+      balances[split.memberId] = (balances[split.memberId] ?? 0) - eurCents;
     }
 
-    // Apply settlements: fromMember paid toMember (in cents)
+    // Apply settlements: fromMember paid toMember.
+    // Settlements are stored in the group's display currency.
     for (final s in settlements) {
-      balances[s.fromMemberId] =
-          (balances[s.fromMemberId] ?? 0) + s.amountCents;
-      balances[s.toMemberId] =
-          (balances[s.toMemberId] ?? 0) - s.amountCents;
+      final eurCents = CurrencyConverter.toEurCents(s.amountCents, displayCurrency);
+      balances[s.fromMemberId] = (balances[s.fromMemberId] ?? 0) + eurCents;
+      balances[s.toMemberId]   = (balances[s.toMemberId]   ?? 0) - eurCents;
     }
 
+    // Convert results back to the group's display currency
     return members.map((member) {
+      final eurCents = balances[member.id] ?? 0;
+      final displayCents = CurrencyConverter.fromEurCents(eurCents, displayCurrency);
       return MemberBalance(
         member: member,
-        netBalanceCents: balances[member.id] ?? 0,
+        netBalanceCents: displayCents,
       );
     }).toList();
   }
@@ -69,10 +84,13 @@ class DebtCalculator {
     List<ExpenseSplit> splits, {
     List<SettlementRecord> settlements = const [],
     List<ExpensePayer> payers = const [],
+    String displayCurrency = 'EUR',
   }) {
     final netBalances = calculateNetBalances(
       members, expenses, splits,
-      settlements: settlements, payers: payers,
+      settlements: settlements,
+      payers: payers,
+      displayCurrency: displayCurrency,
     );
     final result = <Settlement>[];
 

--- a/lib/features/expenses/screens/add_expense_wizard.dart
+++ b/lib/features/expenses/screens/add_expense_wizard.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import '../../../core/services/notification_service.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/utils/currency_utils.dart';
 import '../../activity/providers/activity_provider.dart';
 import '../../activity/services/activity_logger.dart';
 import '../../groups/models/group.dart';
@@ -32,6 +33,7 @@ class _AddExpenseWizardState extends ConsumerState<AddExpenseWizard> {
   String _selectedCategory = 'general';
   final Set<String> _selectedPayerIds = {};
   DateTime _selectedDate = DateTime.now();
+  String _selectedCurrency = 'USD'; // defaults to group currency, set in initState
 
   // Step 2 fields
   String _splitType = 'equal';
@@ -45,6 +47,7 @@ class _AddExpenseWizardState extends ConsumerState<AddExpenseWizard> {
   @override
   void initState() {
     super.initState();
+    _selectedCurrency = widget.group.currency;
     _descriptionController.addListener(_onDescriptionChanged);
   }
 
@@ -177,6 +180,7 @@ class _AddExpenseWizardState extends ConsumerState<AddExpenseWizard> {
         splitAmongIds: _selectedSplitMemberIds.toList(),
         category: _selectedCategory,
         splitType: _splitType,
+        currency: _selectedCurrency,
         expenseDate: _selectedDate,
         customSplits: customSplits,
       );
@@ -527,6 +531,32 @@ class _AddExpenseWizardState extends ConsumerState<AddExpenseWizard> {
                 ],
               ),
             ),
+          ),
+          const SizedBox(height: 16),
+          // Currency selector
+          Row(
+            children: [
+              Text('Currency', style: Theme.of(context).textTheme.titleSmall),
+              const SizedBox(width: 16),
+              Expanded(
+                child: DropdownButtonFormField<String>(
+                  value: _selectedCurrency,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                  ),
+                  items: CurrencyConverter.supportedCurrencies.map((code) {
+                    return DropdownMenuItem(
+                      value: code,
+                      child: Text('$code  ${getCurrencySymbol(code)}'),
+                    );
+                  }).toList(),
+                  onChanged: (value) {
+                    if (value != null) setState(() => _selectedCurrency = value);
+                  },
+                ),
+              ),
+            ],
           ),
           const SizedBox(height: 16),
           // Custom numpad


### PR DESCRIPTION
## Problem
Different currencies were being added together without conversion, resulting in incorrect balances (e.g., 100 USD + 100 EUR = 200 "money").

## Solution
- Added `CurrencyConverter` class in `currency_utils.dart` with static EUR-based exchange rates
  - TODO: live rates — replace with ECB/Fixer.io API in a future sprint
- `DebtCalculator`: converts all amounts to EUR cents before arithmetic, then converts back to the group's display currency
- `balances_provider`: reads group currency and passes as `displayCurrency`
- `add_expense_wizard`: added currency dropdown per expense (defaults to group currency)

Closes #22, Closes #38. Static exchange rates for now, live rates planned.