### PR TITLE
feat: Live exchange rates via Frankfurter API (no API key needed)

### DIFF
--- a/lib/core/utils/currency_utils.dart
+++ b/lib/core/utils/currency_utils.dart
@@ -1,3 +1,8 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
 const currencySymbols = <String, String>{
   'USD': '\$',
   'EUR': '€',
@@ -39,12 +44,21 @@ String getCurrencySymbol(String currency) {
 }
 
 /// Currency converter using EUR as the base currency.
-/// TODO: live rates — replace static rates with an API call (e.g. ECB, Fixer.io)
+/// Fetches live rates from Frankfurter.app (free, no API key, FOSS).
+/// Caches rates for 24h via SharedPreferences.
+/// Falls back to static rates when offline.
 class CurrencyConverter {
   CurrencyConverter._();
 
-  /// Exchange rates relative to EUR (1 EUR = X currency).
-  static const Map<String, double> _ratesFromEur = {
+  static const _cacheKey = 'frankfurter_rates_json';
+  static const _cacheTimestampKey = 'frankfurter_rates_timestamp';
+  static const _cacheTtlMs = 24 * 60 * 60 * 1000; // 24 hours
+
+  // In-memory cache — populated on first use
+  static Map<String, double>? _liveRates;
+
+  /// Static fallback rates relative to EUR (1 EUR = X currency).
+  static const Map<String, double> _staticRatesFromEur = {
     'EUR': 1.0,
     'USD': 1.08,
     'GBP': 0.86,
@@ -72,20 +86,87 @@ class CurrencyConverter {
     'ZAR': 20.2,
   };
 
+  /// Active rates — live if available, otherwise static fallback.
+  static Map<String, double> get _rates => _liveRates ?? _staticRatesFromEur;
+
+  /// Initialises the converter by loading cached or fetching live rates.
+  /// Call once at app startup (e.g. in main.dart after WidgetsFlutterBinding).
+  static Future<void> init() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final cachedJson = prefs.getString(_cacheKey);
+      final cachedTs = prefs.getInt(_cacheTimestampKey) ?? 0;
+      final now = DateTime.now().millisecondsSinceEpoch;
+
+      if (cachedJson != null && (now - cachedTs) < _cacheTtlMs) {
+        // Use cached rates
+        final decoded = jsonDecode(cachedJson) as Map<String, dynamic>;
+        _liveRates = {
+          'EUR': 1.0,
+          ...decoded.map((k, v) => MapEntry(k, (v as num).toDouble())),
+        };
+        debugPrint('[Currency] Using cached rates (age: ${(now - cachedTs) ~/ 60000}min)');
+        return;
+      }
+
+      // Fetch fresh rates from Frankfurter API
+      await _fetchAndCache(prefs);
+    } catch (e) {
+      debugPrint('[Currency] init failed, using static rates: $e');
+    }
+  }
+
+  /// Forces a refresh of live rates (ignores cache).
+  static Future<void> refresh() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await _fetchAndCache(prefs);
+    } catch (e) {
+      debugPrint('[Currency] refresh failed: $e');
+    }
+  }
+
+  static Future<void> _fetchAndCache(SharedPreferences prefs) async {
+    const url = 'https://api.frankfurter.app/latest?from=EUR';
+    debugPrint('[Currency] Fetching live rates from $url');
+
+    final response = await http
+        .get(Uri.parse(url))
+        .timeout(const Duration(seconds: 10));
+
+    if (response.statusCode == 200) {
+      final body = jsonDecode(response.body) as Map<String, dynamic>;
+      final rates = body['rates'] as Map<String, dynamic>;
+
+      _liveRates = {
+        'EUR': 1.0,
+        ...rates.map((k, v) => MapEntry(k, (v as num).toDouble())),
+      };
+
+      await prefs.setString(_cacheKey, jsonEncode(rates));
+      await prefs.setInt(
+          _cacheTimestampKey, DateTime.now().millisecondsSinceEpoch);
+
+      debugPrint('[Currency] Live rates updated (${_liveRates!.length} currencies)');
+    } else {
+      debugPrint('[Currency] API returned ${response.statusCode}, using fallback rates');
+    }
+  }
+
   /// Convert [amountCents] from [fromCurrency] to EUR cents.
   /// Returns amountCents unchanged if the currency is unknown (fail-open).
   static int toEurCents(int amountCents, String fromCurrency) {
     if (fromCurrency == 'EUR') return amountCents;
-    final rate = _ratesFromEur[fromCurrency];
-    if (rate == null || rate == 0) return amountCents; // unknown currency — pass through
+    final rate = _rates[fromCurrency];
+    if (rate == null || rate == 0) return amountCents;
     return (amountCents / rate).round();
   }
 
   /// Convert [eurCents] from EUR to [toCurrency] cents.
   static int fromEurCents(int eurCents, String toCurrency) {
     if (toCurrency == 'EUR') return eurCents;
-    final rate = _ratesFromEur[toCurrency];
-    if (rate == null) return eurCents; // unknown currency — pass through
+    final rate = _rates[toCurrency];
+    if (rate == null) return eurCents;
     return (eurCents * rate).round();
   }
 
@@ -96,10 +177,13 @@ class CurrencyConverter {
     return fromEurCents(eurCents, toCurrency);
   }
 
-  /// Whether a currency code is known.
-  static bool isSupported(String currency) => _ratesFromEur.containsKey(currency);
+  /// Whether a currency code is known (live or static).
+  static bool isSupported(String currency) => _rates.containsKey(currency);
 
   /// Sorted list of supported currency codes.
   static List<String> get supportedCurrencies =>
-      _ratesFromEur.keys.toList()..sort();
+      _rates.keys.toList()..sort();
+
+  /// True when live rates have been loaded successfully.
+  static bool get hasLiveRates => _liveRates != null;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   connectivity_plus: ^6.1.0
   shared_preferences: ^2.3.4
   flutter_secure_storage: ^9.2.2
+  http: ^1.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
Replaces static exchange rates with live data from Frankfurter.app.

## Changes
- `lib/core/utils/currency_utils.dart`: Full rewrite of `CurrencyConverter`
  - Frankfurter.app API (FOSS, free, no API key required)
  - 24h disk cache via `SharedPreferences`
  - In-memory cache for instant access after first load
  - Graceful offline fallback to static rates
  - `CurrencyConverter.init()` — call once at app startup
  - `CurrencyConverter.refresh()` — force refresh
  - `CurrencyConverter.hasLiveRates` — status flag
- `pubspec.yaml`: Added `http: ^1.2.2`

## Usage
```dart
// In main.dart, after WidgetsFlutterBinding.ensureInitialized()
await CurrencyConverter.init();
```

## API
- Endpoint: https://api.frankfurter.app/latest?from=EUR
- Rate limit: none (free tier)
- Offline: falls back to static rates silently

Closes #35 (if tracked) — replaces static rates with live data.