### PR TITLE
feat: Push notifications via ntfy.sh (self-hosted friendly)

### DIFF
--- a/lib/core/config/ntfy_config.dart
+++ b/lib/core/config/ntfy_config.dart
@@ -1,0 +1,45 @@
+/// ntfy.sh configuration for self-hosted push notifications.
+///
+/// CEO policy: self-hosted first — no vendor lock-in.
+/// Default points to the public ntfy.sh server.
+/// To use a self-hosted instance (e.g. on Hetzner):
+///   1. Deploy ntfy: `docker run -p 80:80 binwiederhier/ntfy serve`
+///   2. Change [ntfyBaseUrl] to your server URL, e.g. "https://ntfy.yourdomain.com"
+class NtfyConfig {
+  NtfyConfig._();
+
+  /// Base URL of the ntfy server.
+  /// Override with your self-hosted instance URL.
+  ///
+  /// Example (public):    "https://ntfy.sh"
+  /// Example (Hetzner):   "https://ntfy.example.com"
+  static const String ntfyBaseUrl = String.fromEnvironment(
+    'NTFY_BASE_URL',
+    defaultValue: 'https://ntfy.sh',
+  );
+
+  /// Topic prefix to avoid collisions on the public server.
+  /// Topics are constructed as: "$topicPrefix-$groupUuid"
+  ///
+  /// On a self-hosted server this can be left empty ("").
+  static const String topicPrefix = String.fromEnvironment(
+    'NTFY_TOPIC_PREFIX',
+    defaultValue: 'splitgenesis',
+  );
+
+  /// Optional Bearer token for authenticated ntfy instances.
+  /// Leave empty for public/open server.
+  ///
+  /// Set via:  flutter run --dart-define=NTFY_TOKEN=tk_yourtoken
+  static const String ntfyToken = String.fromEnvironment(
+    'NTFY_TOKEN',
+    defaultValue: '',
+  );
+
+  /// Build the topic name for a given group UUID.
+  /// Format: "{prefix}-{groupUuid}" (public) or "{groupUuid}" (self-hosted).
+  static String topicForGroup(String groupUuid) {
+    if (topicPrefix.isEmpty) return groupUuid;
+    return '$topicPrefix-$groupUuid';
+  }
+}

--- a/lib/core/services/notification_service.dart
+++ b/lib/core/services/notification_service.dart
@@ -1,11 +1,40 @@
-import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'dart:convert';
 
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:http/http.dart' as http;
+
+import '../config/ntfy_config.dart';
+
+/// Handles both local (on-device) and remote (ntfy.sh) push notifications.
+///
+/// ## Architecture
+/// - **Local notifications**: shown via [flutter_local_notifications] for
+///   immediate in-app feedback (current user's device).
+/// - **ntfy.sh push**: sent via HTTP POST so *other* group members receive
+///   a push notification on their devices (they subscribe to the group topic).
+///
+/// ## ntfy.sh Topic Strategy
+/// Each group gets a unique topic derived from its UUID:
+///   `splitgenesis-{groupUuid}` (public server)
+///   `{groupUuid}` (self-hosted server with [NtfyConfig.topicPrefix] = "")
+///
+/// Users subscribe to their groups' topics using the ntfy app or any ntfy client.
+///
+/// ## Self-hosted Setup (CEO / Hetzner)
+/// ```
+/// docker run -p 80:80 binwiederhier/ntfy serve
+/// ```
+/// Then set `NTFY_BASE_URL=https://ntfy.yourdomain.com` via `--dart-define`.
 class NotificationService {
   NotificationService._();
   static final NotificationService instance = NotificationService._();
 
   final FlutterLocalNotificationsPlugin _plugin =
       FlutterLocalNotificationsPlugin();
+
+  // ──────────────────────────────────────────────
+  // Initialisation
+  // ──────────────────────────────────────────────
 
   Future<void> initialize() async {
     const androidSettings =
@@ -22,51 +51,235 @@ class NotificationService {
     await _plugin.initialize(settings);
   }
 
+  // ──────────────────────────────────────────────
+  // Local notification helpers
+  // ──────────────────────────────────────────────
+
+  Future<void> _showLocal({
+    required String title,
+    required String body,
+    String channel = 'expenses',
+    String channelName = 'Expenses',
+    String channelDescription = 'Expense notifications',
+  }) async {
+    final androidDetails = AndroidNotificationDetails(
+      channel,
+      channelName,
+      channelDescription: channelDescription,
+      importance: Importance.defaultImportance,
+      priority: Priority.defaultPriority,
+    );
+    final details = NotificationDetails(
+      android: androidDetails,
+      iOS: const DarwinNotificationDetails(),
+    );
+    await _plugin.show(
+      DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      title,
+      body,
+      details,
+    );
+  }
+
+  // ──────────────────────────────────────────────
+  // ntfy.sh remote push
+  // ──────────────────────────────────────────────
+
+  /// Send a push notification to all subscribers of [groupUuid]'s topic.
+  ///
+  /// Uses HTTP POST to the ntfy server as documented at https://ntfy.sh/docs/publish/
+  ///
+  /// Headers supported:
+  ///   - `Title`: notification title
+  ///   - `Priority`: 1 (min) – 5 (max), default 3
+  ///   - `Tags`: comma-separated ntfy emoji tags, e.g. "money_with_wings"
+  ///   - `Authorization`: Bearer token (if self-hosted + auth enabled)
+  Future<void> _sendNtfy({
+    required String groupUuid,
+    required String title,
+    required String body,
+    String priority = '3',
+    String tags = '',
+  }) async {
+    final topic = NtfyConfig.topicForGroup(groupUuid);
+    final url = Uri.parse('${NtfyConfig.ntfyBaseUrl}/$topic');
+
+    final headers = <String, String>{
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Title': title,
+      'Priority': priority,
+      if (tags.isNotEmpty) 'Tags': tags,
+      if (NtfyConfig.ntfyToken.isNotEmpty)
+        'Authorization': 'Bearer ${NtfyConfig.ntfyToken}',
+    };
+
+    try {
+      final response = await http
+          .post(url, headers: headers, body: utf8.encode(body))
+          .timeout(const Duration(seconds: 10));
+
+      if (response.statusCode >= 400) {
+        // Log but don't throw — push failure should never crash the app
+        // ignore: avoid_print
+        print(
+          '[ntfy] Push failed for topic $topic: '
+          'HTTP ${response.statusCode} — ${response.body}',
+        );
+      }
+    } catch (e) {
+      // Network error: silently ignore (offline-first app)
+      // ignore: avoid_print
+      print('[ntfy] Push error for topic $topic: $e');
+    }
+  }
+
+  // ──────────────────────────────────────────────
+  // Public API — Expense events
+  // ──────────────────────────────────────────────
+
+  /// Notify group members that a new expense was added.
+  ///
+  /// Call this after successfully persisting the expense to the database.
   Future<void> showExpenseAdded({
     required String groupName,
     required String description,
     required double amount,
     required String paidByName,
+    String? groupUuid,
   }) async {
-    const androidDetails = AndroidNotificationDetails(
-      'expenses',
-      'Expenses',
-      channelDescription: 'Expense notifications',
-      importance: Importance.defaultImportance,
-      priority: Priority.defaultPriority,
-    );
-    const details = NotificationDetails(
-      android: androidDetails,
-      iOS: DarwinNotificationDetails(),
-    );
-    await _plugin.show(
-      DateTime.now().millisecondsSinceEpoch ~/ 1000,
-      'Expense added to $groupName',
-      '$paidByName paid \$${amount.toStringAsFixed(2)} for $description',
-      details,
-    );
+    final title = 'New expense in $groupName';
+    final body =
+        '$paidByName paid \$${amount.toStringAsFixed(2)} for $description';
+
+    // Local notification for the current user
+    await _showLocal(title: title, body: body);
+
+    // Remote push for other group members
+    if (groupUuid != null) {
+      await _sendNtfy(
+        groupUuid: groupUuid,
+        title: title,
+        body: body,
+        priority: '3',
+        tags: 'money_with_wings',
+      );
+    }
   }
 
+  /// Notify group members that an expense was updated.
   Future<void> showExpenseUpdated({
     required String groupName,
     required String description,
+    String? groupUuid,
   }) async {
-    const androidDetails = AndroidNotificationDetails(
-      'expenses',
-      'Expenses',
-      channelDescription: 'Expense notifications',
-      importance: Importance.defaultImportance,
-      priority: Priority.defaultPriority,
+    final title = 'Expense updated in $groupName';
+    const body = 'An expense was updated.';
+
+    await _showLocal(title: title, body: description);
+
+    if (groupUuid != null) {
+      await _sendNtfy(
+        groupUuid: groupUuid,
+        title: title,
+        body: description,
+        priority: '2',
+        tags: 'pencil',
+      );
+    }
+  }
+
+  // ──────────────────────────────────────────────
+  // Public API — Debt events
+  // ──────────────────────────────────────────────
+
+  /// Notify group members that a debt was settled.
+  Future<void> showDebtSettled({
+    required String groupName,
+    required String settledByName,
+    required double amount,
+    required String owedToName,
+    String? groupUuid,
+  }) async {
+    final title = 'Debt settled in $groupName';
+    final body =
+        '$settledByName settled \$${amount.toStringAsFixed(2)} with $owedToName';
+
+    await _showLocal(
+      title: title,
+      body: body,
+      channel: 'settlements',
+      channelName: 'Settlements',
+      channelDescription: 'Debt settlement notifications',
     );
-    const details = NotificationDetails(
-      android: androidDetails,
-      iOS: DarwinNotificationDetails(),
+
+    if (groupUuid != null) {
+      await _sendNtfy(
+        groupUuid: groupUuid,
+        title: title,
+        body: body,
+        priority: '3',
+        tags: 'white_check_mark',
+      );
+    }
+  }
+
+  // ──────────────────────────────────────────────
+  // Public API — Member events
+  // ──────────────────────────────────────────────
+
+  /// Notify group members that a new member joined.
+  Future<void> showMemberJoined({
+    required String groupName,
+    required String memberName,
+    String? groupUuid,
+  }) async {
+    final title = 'New member in $groupName';
+    final body = '$memberName joined the group.';
+
+    await _showLocal(
+      title: title,
+      body: body,
+      channel: 'members',
+      channelName: 'Members',
+      channelDescription: 'Group membership notifications',
     );
-    await _plugin.show(
-      DateTime.now().millisecondsSinceEpoch ~/ 1000,
-      'Expense updated in $groupName',
-      description,
-      details,
+
+    if (groupUuid != null) {
+      await _sendNtfy(
+        groupUuid: groupUuid,
+        title: title,
+        body: body,
+        priority: '2',
+        tags: 'wave',
+      );
+    }
+  }
+
+  /// Notify group members that a member left.
+  Future<void> showMemberLeft({
+    required String groupName,
+    required String memberName,
+    String? groupUuid,
+  }) async {
+    final title = 'Member left $groupName';
+    final body = '$memberName left the group.';
+
+    await _showLocal(
+      title: title,
+      body: body,
+      channel: 'members',
+      channelName: 'Members',
+      channelDescription: 'Group membership notifications',
     );
+
+    if (groupUuid != null) {
+      await _sendNtfy(
+        groupUuid: groupUuid,
+        title: title,
+        body: body,
+        priority: '2',
+        tags: 'wave',
+      );
+    }
   }
 }

--- a/team-discussion.md
+++ b/team-discussion.md
@@ -344,3 +344,44 @@ Push Notifications: ntfy.sh prüfen bevor Firebase — kein Lock-in, kein Google
 
 ---
 *CTO | Sprint 11 | 2026-03-14*
+
+---
+
+## Sprint 11 — SeniorDev | ntfy.sh Push Notifications | 2026-03-14
+
+### Feature: Push Notifications via ntfy.sh (self-hosted friendly)
+
+**Branch:** `feature/push-notifications-ntfy`
+
+**Implementiert:**
+
+#### lib/core/config/ntfy_config.dart (neu)
+- `ntfyBaseUrl`: konfigurierbar via `--dart-define=NTFY_BASE_URL=...` (default: `https://ntfy.sh`)
+- `topicPrefix`: `splitgenesis` auf Public-Server, leer auf self-hosted → kein Topic-Konflikt
+- `ntfyToken`: Optional Bearer Auth für private ntfy-Instanzen
+- `topicForGroup(uuid)`: baut Topic-Namen pro Gruppe
+
+#### lib/core/services/notification_service.dart (erweitert)
+- `_sendNtfy()`: HTTP POST zu ntfy-Server
+  - Headers: Title, Priority, Tags (Emoji), optional Bearer Token
+  - 10s Timeout, silent error handling (Offline-First — Push-Fehler crasht nie die App)
+- `showExpenseAdded()`: lokal + remote push, Tags: money_with_wings
+- `showExpenseUpdated()`: lokal + remote push, Tags: pencil
+- `showDebtSettled()`: NEU — lokal + remote push, Tags: white_check_mark
+- `showMemberJoined()`: NEU — lokal + remote push, Tags: wave
+- `showMemberLeft()`: NEU — lokal + remote push, Tags: wave
+
+**Alle bestehenden Calls rückwärtskompatibel** — `groupUuid` optional, ntfy wird nur gesendet wenn vorhanden.
+
+**Self-Hosted Setup (CEO / Hetzner):**
+```bash
+docker run -p 80:80 binwiederhier/ntfy serve
+# dann: --dart-define=NTFY_BASE_URL=https://ntfy.yourdomain.com
+```
+
+**Nutzer-Flow:**
+1. Gruppe erstellen → Topic: `splitgenesis-{groupUuid}`
+2. Andere Mitglieder subscriben via ntfy-App auf dieses Topic
+3. Bei neuer Ausgabe/Zahlung/Mitglied → HTTP POST → alle subscribierten Mitglieder erhalten Push
+
+*SeniorDev | Sprint 11 | 2026-03-14*


### PR DESCRIPTION
## Summary

Self-hosted push notifications via ntfy.sh. No Firebase, no vendor lock-in. CEO can run own ntfy instance on Hetzner.

## New Files

### `lib/core/config/ntfy_config.dart`
Central ntfy configuration:
- `ntfyBaseUrl` — configurable via `--dart-define=NTFY_BASE_URL=...` (default: `https://ntfy.sh`)
- `topicPrefix` — `splitgenesis` on public server, empty on self-hosted
- `ntfyToken` — optional Bearer auth for private/protected ntfy instances
- `topicForGroup(uuid)` — builds topic name from group UUID

## Changes

### `lib/core/services/notification_service.dart`
Extended with ntfy.sh channel alongside existing local notifications:

| Method | Event | ntfy Tags |
|--------|-------|-----------|
| `showExpenseAdded()` | New expense added to group | 💸 money_with_wings |
| `showExpenseUpdated()` | Expense updated | ✏️ pencil |
| `showDebtSettled()` | **NEW** — Debt paid off | ✅ white_check_mark |
| `showMemberJoined()` | **NEW** — New member joined | 👋 wave |
| `showMemberLeft()` | **NEW** — Member left group | 👋 wave |

All methods: local notification + HTTP POST to ntfy. Backwards-compatible (`groupUuid` is optional).

## Self-Hosted Setup (Hetzner)
```bash
docker run -p 80:80 binwiederhier/ntfy serve
# Build app with:
flutter run --dart-define=NTFY_BASE_URL=https://ntfy.yourdomain.com
```

## How It Works
1. Each group gets a topic: `splitgenesis-{groupUuid}`
2. Group members subscribe via ntfy app (Android/iOS/Web)
3. On any group event → HTTP POST → all subscribers notified instantly

## Why ntfy.sh?
- Open source (Apache 2.0)
- Docker-deployable in 30 seconds
- No Google account / Firebase required
- End-to-end compatible with Hetzner self-hosting philosophy
- Free public tier available for testing