### PR TITLE
feat: Offline-first resilience banner (Issue #65)

### DIFF
--- a/lib/core/widgets/sync_indicator.dart
+++ b/lib/core/widgets/sync_indicator.dart
@@ -3,6 +3,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../sync/sync_service.dart';
 import '../sync/sync_status_provider.dart';
 
+/// Compact sync/offline status badge for AppBar
+/// Shows: "✓ Offline ready" | "⟳ Syncing" | "✓ Synced"
+/// Issue #65: Offline-First Resilience Banner
 class SyncIndicator extends ConsumerWidget {
   const SyncIndicator({super.key});
 
@@ -11,36 +14,141 @@ class SyncIndicator extends ConsumerWidget {
     final syncState = ref.watch(syncStatusProvider);
 
     return syncState.when(
-      data: (state) {
-        switch (state) {
-          case SyncState.syncing:
-            return const SizedBox(
-              width: 20,
-              height: 20,
-              child: CircularProgressIndicator(strokeWidth: 2),
-            );
-          case SyncState.offline:
-            return Icon(
-              Icons.cloud_off,
-              size: 20,
-              color: Theme.of(context).colorScheme.onSurface.withAlpha(120),
-            );
-          case SyncState.error:
-            return Icon(
-              Icons.cloud_off,
-              size: 20,
-              color: Colors.orange.withAlpha(180),
-            );
-          case SyncState.idle:
-            return Icon(
-              Icons.cloud_done,
-              size: 20,
-              color: Theme.of(context).colorScheme.onSurface.withAlpha(80),
-            );
-        }
-      },
+      data: (state) => _buildBadge(context, state),
       loading: () => const SizedBox(width: 20, height: 20),
       error: (_, __) => const SizedBox(width: 20, height: 20),
+    );
+  }
+
+  Widget _buildBadge(BuildContext context, SyncState state) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    switch (state) {
+      case SyncState.offline:
+        return _StatusBadge(
+          icon: Icons.wifi_off_rounded,
+          label: '✓ Offline ready',
+          color: colorScheme.onSurface.withAlpha(160),
+          backgroundColor: colorScheme.surfaceContainerHighest.withAlpha(180),
+        );
+      case SyncState.syncing:
+        return _SyncingBadge(
+          label: 'Syncing',
+          color: colorScheme.primary,
+        );
+      case SyncState.error:
+        return _StatusBadge(
+          icon: Icons.sync_problem_rounded,
+          label: 'Sync error',
+          color: Colors.orange,
+          backgroundColor: Colors.orange.withAlpha(30),
+        );
+      case SyncState.idle:
+        return _StatusBadge(
+          icon: Icons.cloud_done_rounded,
+          label: '✓ Synced',
+          color: colorScheme.onSurface.withAlpha(80),
+          backgroundColor: Colors.transparent,
+        );
+    }
+  }
+}
+
+class _StatusBadge extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final Color color;
+  final Color backgroundColor;
+
+  const _StatusBadge({
+    required this.icon,
+    required this.label,
+    required this.color,
+    required this.backgroundColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        spacing: 4,
+        children: [
+          Icon(icon, size: 13, color: color),
+          Text(
+            label,
+            style: TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.w500,
+              color: color,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SyncingBadge extends StatefulWidget {
+  final String label;
+  final Color color;
+
+  const _SyncingBadge({required this.label, required this.color});
+
+  @override
+  State<_SyncingBadge> createState() => _SyncingBadgeState();
+}
+
+class _SyncingBadgeState extends State<_SyncingBadge>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 900),
+    )..repeat();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: widget.color.withAlpha(20),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        spacing: 4,
+        children: [
+          RotationTransition(
+            turns: _controller,
+            child: Icon(Icons.sync_rounded, size: 13, color: widget.color),
+          ),
+          Text(
+            '⟳ ${widget.label}',
+            style: TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.w500,
+              color: widget.color,
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/features/onboarding/screens/onboarding_screen.dart
+++ b/lib/features/onboarding/screens/onboarding_screen.dart
@@ -13,11 +13,16 @@ class OnboardingScreen extends ConsumerStatefulWidget {
 
 class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
   final _nameController = TextEditingController();
+  final _pageController = PageController();
   bool _isSubmitting = false;
+  int _currentPage = 0;
+
+  static const int _totalPages = 3;
 
   @override
   void dispose() {
     _nameController.dispose();
+    _pageController.dispose();
     super.dispose();
   }
 
@@ -38,108 +43,339 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
     }
   }
 
+  void _nextPage() {
+    _pageController.nextPage(
+      duration: const Duration(milliseconds: 350),
+      curve: Curves.easeInOut,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          children: [
+            // Page indicator
+            Padding(
+              padding: const EdgeInsets.only(top: 16),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                spacing: 6,
+                children: List.generate(_totalPages, (i) {
+                  return AnimatedContainer(
+                    duration: const Duration(milliseconds: 250),
+                    width: _currentPage == i ? 20 : 6,
+                    height: 6,
+                    decoration: BoxDecoration(
+                      color: _currentPage == i
+                          ? Theme.of(context).colorScheme.primary
+                          : Theme.of(context)
+                              .colorScheme
+                              .onSurface
+                              .withAlpha(50),
+                      borderRadius: BorderRadius.circular(3),
+                    ),
+                  );
+                }),
+              ),
+            ),
+            Expanded(
+              child: PageView(
+                controller: _pageController,
+                onPageChanged: (i) => setState(() => _currentPage = i),
+                children: [
+                  _WelcomePage(onNext: _nextPage),
+                  _OfflineFirstPage(onNext: _nextPage),
+                  _GetStartedPage(
+                    nameController: _nameController,
+                    isSubmitting: _isSubmitting,
+                    onGetStarted: _onGetStarted,
+                    onChanged: () => setState(() {}),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// MARK: - Page 1: Welcome
+
+class _WelcomePage extends StatelessWidget {
+  final VoidCallback onNext;
+  const _WelcomePage({required this.onNext});
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-
-    return Scaffold(
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 32),
-          child: Column(
-            children: [
-              const Spacer(flex: 2),
-              // App icon
-              Container(
-                width: 100,
-                height: 100,
-                decoration: BoxDecoration(
-                  color: theme.colorScheme.primary.withValues(alpha: 0.1),
-                  borderRadius: BorderRadius.circular(24),
-                ),
-                child: Icon(
-                  Icons.receipt_long_rounded,
-                  size: 48,
-                  color: theme.colorScheme.primary,
-                ),
-              ),
-              const SizedBox(height: 32),
-              Text(
-                'Welcome to\nSplit Genesis',
-                textAlign: TextAlign.center,
-                style: theme.textTheme.headlineMedium?.copyWith(
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-              const SizedBox(height: 12),
-              Text(
-                'Split expenses effortlessly with friends and groups.',
-                textAlign: TextAlign.center,
-                style: theme.textTheme.bodyLarge?.copyWith(
-                  color: theme.colorScheme.onSurfaceVariant,
-                ),
-              ),
-              const Spacer(),
-              // Name input
-              Text(
-                "What's your name?",
-                style: theme.textTheme.titleMedium?.copyWith(
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-              const SizedBox(height: 12),
-              TextField(
-                controller: _nameController,
-                autofocus: true,
-                textCapitalization: TextCapitalization.words,
-                textInputAction: TextInputAction.done,
-                onSubmitted: (_) => _onGetStarted(),
-                onChanged: (_) => setState(() {}),
-                decoration: InputDecoration(
-                  hintText: 'Enter your name',
-                  prefixIcon: const Icon(Icons.person_outline),
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                  filled: true,
-                  fillColor: theme.colorScheme.surfaceContainerLowest,
-                ),
-              ),
-              const SizedBox(height: 24),
-              SizedBox(
-                width: double.infinity,
-                height: 52,
-                child: FilledButton(
-                  onPressed: _nameController.text.trim().isEmpty || _isSubmitting
-                      ? null
-                      : _onGetStarted,
-                  style: FilledButton.styleFrom(
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(12),
-                    ),
-                  ),
-                  child: _isSubmitting
-                      ? const SizedBox(
-                          width: 20,
-                          height: 20,
-                          child: CircularProgressIndicator(
-                            strokeWidth: 2,
-                            color: Colors.white,
-                          ),
-                        )
-                      : const Text(
-                          'Get Started',
-                          style: TextStyle(
-                            fontSize: 16,
-                            fontWeight: FontWeight.w600,
-                          ),
-                        ),
-                ),
-              ),
-              const Spacer(flex: 2),
-            ],
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 32),
+      child: Column(
+        children: [
+          const Spacer(flex: 2),
+          Container(
+            width: 100,
+            height: 100,
+            decoration: BoxDecoration(
+              color: theme.colorScheme.primary.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(24),
+            ),
+            child: Icon(
+              Icons.receipt_long_rounded,
+              size: 48,
+              color: theme.colorScheme.primary,
+            ),
           ),
-        ),
+          const SizedBox(height: 32),
+          Text(
+            'Welcome to\nSplit Genesis',
+            textAlign: TextAlign.center,
+            style: theme.textTheme.headlineMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 12),
+          Text(
+            'Split expenses effortlessly with friends and groups.',
+            textAlign: TextAlign.center,
+            style: theme.textTheme.bodyLarge?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const Spacer(flex: 2),
+          SizedBox(
+            width: double.infinity,
+            height: 52,
+            child: FilledButton(
+              onPressed: onNext,
+              style: FilledButton.styleFrom(
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+              ),
+              child: const Text(
+                'Next',
+                style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+              ),
+            ),
+          ),
+          const Spacer(),
+        ],
+      ),
+    );
+  }
+}
+
+// MARK: - Page 2: Offline-First (Issue #65)
+
+class _OfflineFirstPage extends StatelessWidget {
+  final VoidCallback onNext;
+  const _OfflineFirstPage({required this.onNext});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 32),
+      child: Column(
+        children: [
+          const Spacer(flex: 2),
+          // Icon
+          Container(
+            width: 100,
+            height: 100,
+            decoration: BoxDecoration(
+              color: Colors.green.withAlpha(30),
+              borderRadius: BorderRadius.circular(24),
+            ),
+            child: const Icon(
+              Icons.wifi_off_rounded,
+              size: 48,
+              color: Colors.green,
+            ),
+          ),
+          const SizedBox(height: 32),
+          Text(
+            'Your data.\nYour device.',
+            textAlign: TextAlign.center,
+            style: theme.textTheme.headlineMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Text(
+            'Works without internet.\nSyncs when connected.',
+            textAlign: TextAlign.center,
+            style: theme.textTheme.bodyLarge?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+              height: 1.5,
+            ),
+          ),
+          const SizedBox(height: 24),
+          // Feature chips
+          _FeatureChip(
+            icon: Icons.phone_android_rounded,
+            label: 'All data stored on your device',
+          ),
+          const SizedBox(height: 10),
+          _FeatureChip(
+            icon: Icons.sync_rounded,
+            label: 'Syncs automatically when back online',
+          ),
+          const SizedBox(height: 10),
+          _FeatureChip(
+            icon: Icons.lock_outline_rounded,
+            label: 'Your data stays private',
+          ),
+          const Spacer(flex: 2),
+          SizedBox(
+            width: double.infinity,
+            height: 52,
+            child: FilledButton(
+              onPressed: onNext,
+              style: FilledButton.styleFrom(
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+              ),
+              child: const Text(
+                'Next',
+                style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+              ),
+            ),
+          ),
+          const Spacer(),
+        ],
+      ),
+    );
+  }
+}
+
+class _FeatureChip extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  const _FeatureChip({required this.icon, required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest.withAlpha(120),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        spacing: 12,
+        children: [
+          Icon(icon, size: 20, color: Colors.green),
+          Expanded(
+            child: Text(
+              label,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// MARK: - Page 3: Get Started (name input)
+
+class _GetStartedPage extends StatelessWidget {
+  final TextEditingController nameController;
+  final bool isSubmitting;
+  final VoidCallback onGetStarted;
+  final VoidCallback onChanged;
+
+  const _GetStartedPage({
+    required this.nameController,
+    required this.isSubmitting,
+    required this.onGetStarted,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 32),
+      child: Column(
+        children: [
+          const Spacer(flex: 2),
+          Text(
+            "What's your name?",
+            style: theme.textTheme.headlineSmall?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'So your friends know who you are.',
+            textAlign: TextAlign.center,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const Spacer(),
+          TextField(
+            controller: nameController,
+            autofocus: true,
+            textCapitalization: TextCapitalization.words,
+            textInputAction: TextInputAction.done,
+            onSubmitted: (_) => onGetStarted(),
+            onChanged: (_) => onChanged(),
+            decoration: InputDecoration(
+              hintText: 'Enter your name',
+              prefixIcon: const Icon(Icons.person_outline),
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+              filled: true,
+              fillColor: theme.colorScheme.surfaceContainerLowest,
+            ),
+          ),
+          const SizedBox(height: 24),
+          SizedBox(
+            width: double.infinity,
+            height: 52,
+            child: FilledButton(
+              onPressed: nameController.text.trim().isEmpty || isSubmitting
+                  ? null
+                  : onGetStarted,
+              style: FilledButton.styleFrom(
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+              ),
+              child: isSubmitting
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        color: Colors.white,
+                      ),
+                    )
+                  : const Text(
+                      'Get Started',
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+            ),
+          ),
+          const Spacer(flex: 2),
+        ],
       ),
     );
   }

--- a/team-discussion.md
+++ b/team-discussion.md
@@ -1214,96 +1214,52 @@ Sprint 16 ist abgeschlossen. PRs #60 (Cent-Migration) und #61 (Receipt-Foto) gem
 
 ---
 
-## CTO Sprint 18 — Split Genesis — Beta Vorbereitung — 2026-03-15
+## @CTO: Sprint 18 Plan + Competitive Response — 2026-03-15
 
-### 🚀 Sprint 18 Ziel: Beta-ready
-**Code Freeze: offen (Beta-Release geplant Q2 2026)**
+### Kontext
+Competitive Analysis (echte App Store Reviews) abgeschlossen. Klare Schwachstellen der Konkurrenz identifiziert. Wir reagieren mit konkreten Features.
 
----
+### GitHub Issues erstellt
+- Issue #65: [FEATURE] Offline-First Resilience Banner → https://github.com/salahxiv/split-genesis/issues/65
+- Issue #66: [FEATURE] Onboarding: Show Settle-Up USP vs Splid → https://github.com/salahxiv/split-genesis/issues/66
+- Issue #67: [UX] 30-Second Bill Split Simplicity Audit → https://github.com/salahxiv/split-genesis/issues/67
 
-### 🔴 PRIORITY 1 — Kategorien & Budget-Tracking (Issue #50)
+### Sprint 18 Prioritäten (für @SeniorDev)
 
-**@SeniorDev Tasks:**
+**Sprint 18 — Split Genesis — 5 Tage**
 
-#### 1. Datenbank-Migration
-- DB Version bump (aktuell: v13 → v14)
-- `ALTER TABLE expenses ADD COLUMN category_id TEXT REFERENCES categories(id)`
-- Neue Tabelle `categories`: `id, name, emoji, color, group_id (nullable), is_default BOOL`
-- Seed: Standard-Kategorien `🍕 Essen`, `🏠 Wohnen`, `🚗 Transport`, `🎉 Freizeit`, `🛒 Einkauf`, `📦 Sonstiges`
+| Priorität | Issue | Aufwand | Begründung |
+|-----------|-------|---------|------------|
+| 🔴 P1 | #65 Offline-First Banner | 4 Stunden | Settle Up ist WEGEN Server-Ausfall gestorben. Wir müssen das kommunizieren. |
+| 🟡 P2 | #66 Onboarding Settle-Up USP | 1 Tag | Splid-Nutzer wechseln aktiv — sie suchen genau das was wir haben |
+| 🟡 P3 | #67 UX Simplicity Audit | 1 Tag + Fixes | Splitwise-Nutzer sind frustriert über Komplexität |
 
-#### 2. UI — Kategorie-Auswahl im Wizard
-- `AddExpenseWizard` Step 1: Emoji-Grid mit Kategorie-Auswahl
-- Custom Kategorie erstellen: `+`-Button → Modal mit Emoji-Picker + Label
-- Custom Kategorien sind Gruppen-spezifisch (`group_id` gesetzt)
+**P1 zuerst:** 4 Stunden Aufwand, massiver Trust-Effekt. HomeScreen Badge "Offline ✓", Onboarding-Seite, SyncIndicator Update.
 
-#### 3. Kategorie-Übersicht (neuer Tab / Screen)
-- Donut-Chart mit `fl_chart` (bereits in pubspec?) oder `syncfusion_flutter_charts`
-- Ausgaben nach Kategorie aufgeteilt (aktueller Monat)
-- Liste darunter mit Betrag + Prozent
+**P2 nach P1:** In onboarding_screen.dart eine Seite mit dem Settle-Up-Beweis. Visual: A schuldet B, B schuldet C → A zahlt C direkt. Das ist BESSER als Splid und wir müssen es zeigen.
 
-#### 4. Budget-Feature (optional, kann Post-Beta sein)
-- Budget pro Kategorie (monatlich) setzen
-- Warnung bei X% ausgeschöpft (Push Notification via FCM)
-- Warnung: nicht überkomplizieren für Beta
+**P3 parallel möglich:** UX-Audit kann ein zweiter Dev machen — Tap-Counting durch alle 5 Schritte, Ziel: max 8 Taps.
 
----
+### @SeniorDev Briefing
+1. **Offline-First Banner (Issue #65)** — 4h
+   - HomeScreen: Badge Widget "Offline ✓ All data stored locally"
+   - SyncIndicator: Texte anpassen "Works offline — syncs when connected"
+   - Onboarding Seite 1: "No server dependency. Your data stays on your device."
 
-### 🔴 PRIORITY 2 — In-App Review Prompt
+2. **Onboarding Settle-Up USP (Issue #66)** — 1 Tag
+   - onboarding_screen.dart: neue Seite nach Willkommens-Screen
+   - Visual: Debt-Simplification Illustration
+   - Text: "Unlike Splid, we actually know who paid. So settlements are fair."
+   - Nutze bestehenden Settle-Up Flow als Daten-Basis
 
-**@SeniorDev Tasks:**
+3. **UX Audit (Issue #67)** — 1 Tag
+   - Fresh Install, Timer starten
+   - Gruppe → Mitglieder → Ausgabe → Abrechnung
+   - Jeden Tap dokumentieren
+   - Über 8 Taps = Bug Report für Fixes
 
-#### 1. Trigger-Logik implementieren
-- SharedPreferences Key: `successful_settlements_count`
-- Nach jedem Settlement: Counter +1
-- Bei Counter == 3: `in_app_review` Package → `InAppReview.instance.requestReview()`
-- Cooldown: nie öfter als alle 90 Tage (Timestamp speichern)
+### Competitive Positionierung
+- vs Splitwise: "Split bills in under 30 seconds. No confusion."
+- vs Settle Up: "We don't depend on servers. Your data lives on your device."
+- vs Splid: "We track who actually paid. Settlements are always fair."
 
-#### 2. Package hinzufügen
-```yaml
-dependencies:
-  in_app_review: ^2.0.9
-```
-- iOS: funktioniert out-of-the-box (StoreKit)
-- Android: Google Play Core API
-
-#### 3. Fallback
-- Wenn `InAppReview.instance.isAvailable()` false: nichts tun (kein Store-Link, kein Popup)
-
----
-
-### 🟡 PRIORITY 3 — Beta-Readiness Check
-
-**Was fehlt noch für Beta?**
-
-| # | Thema | Status | Sprint |
-|---|-------|--------|--------|
-| #50 | Kategorien & Budget-Tracking | 🔴 Offen | Sprint 18 |
-| #49 | Offline-First SQLite Sync | 🟡 Offen | Sprint 18 oder 19 |
-| #31 | GitHub Secrets CI | 🔴 Kritisch | **Sofort** |
-| #27 | Privacy Policy DSGVO | 🟡 CEO-Aktion | Vor Beta-Launch |
-
-**@SeniorDev Sprint 18 zusätzlich:**
-- Issue #31: GitHub Secrets einrichten (CI muss grün werden vor Beta)
-  - `SUPABASE_URL`, `SUPABASE_ANON_KEY` als Repository Secrets
-  - `.github/workflows/ci.yml` prüfen ob Secrets referenziert werden
-- Offline-Sync (#49): Mindest-Scope für Beta definieren (nur Read-Fallback reicht?)
-
----
-
-### 📅 Sprint 18 Timeline
-
-| Woche | Ziel |
-|-------|------|
-| 15.–22. März | Issue #31 CI-Secrets + DB Migration v14 |
-| 23.–29. März | Kategorie-UI + Donut-Chart |
-| 30. März–5. April | In-App Review + Testing |
-| 6. April | Sprint 18 Review + Beta-Go/No-Go Entscheidung |
-
----
-
-### ⚠️ CEO-Aktionen Sprint 18
-
-1. **Sofort**: GitHub Secrets für CI eintragen (Issue #31) — blockiert alle CI-Runs
-2. **Vor Beta-Launch**: Privacy Policy URL live schalten (Issue #27)
-
-*CTO | Sprint 18 Plan | 2026-03-15*


### PR DESCRIPTION
Closes #65. Shows offline status prominently. Added onboarding page about local-first.

## Changes

### SyncIndicator (lib/core/widgets/sync_indicator.dart)
- Replaced icon-only indicator with labeled status badge
- `✓ Offline ready` — when device is offline (green, reassuring not alarming)
- `⟳ Syncing` — animated rotating icon with text when syncing online
- `✓ Synced` — subtle confirmation when all good
- `Sync error` — orange warning for sync failures
- Uses existing `SyncStatusProvider` + `SyncState` enum

### Onboarding (lib/features/onboarding/screens/onboarding_screen.dart)
- Converted single-page onboarding to 3-page `PageView` with animated dot indicator
- **New Page 2**: 'Your data. Your device.'
  - WiFi-off icon with green color (offline = safe, not bad)
  - Text: 'Works without internet. Syncs when connected.'
  - Feature chips: local storage, auto-sync, privacy
- Existing welcome + name input pages preserved