### PR TITLE
feat: In-App Review after Settle-Up + 1-tap FAB (#50, #72)

### DIFF
--- a/lib/core/services/review_service.dart
+++ b/lib/core/services/review_service.dart
@@ -1,0 +1,63 @@
+import 'package:in_app_review/in_app_review.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Handles in-app review prompting logic.
+/// Rules:
+///   - Trigger after 3 successful Settle-Ups (not before the first!)
+///   - 90-day cooldown between prompts
+class ReviewService {
+  ReviewService._();
+  static final ReviewService instance = ReviewService._();
+
+  static const String _completedSettleUpsKey = 'review_completed_settle_ups';
+  static const String _lastReviewPromptKey = 'review_last_prompt_date';
+  static const int _requiredSettleUps = 3;
+  static const int _cooldownDays = 90;
+
+  final InAppReview _inAppReview = InAppReview.instance;
+
+  /// Call this after every successful Settle-Up.
+  /// Increments the counter and triggers review prompt when eligible.
+  Future<void> onSettleUpCompleted() async {
+    final prefs = await SharedPreferences.getInstance();
+
+    // Increment settle-up counter
+    final currentCount = prefs.getInt(_completedSettleUpsKey) ?? 0;
+    final newCount = currentCount + 1;
+    await prefs.setInt(_completedSettleUpsKey, newCount);
+
+    // Only attempt review if we've hit the threshold
+    if (newCount < _requiredSettleUps) return;
+
+    // Check 90-day cooldown
+    final lastPromptMs = prefs.getInt(_lastReviewPromptKey);
+    if (lastPromptMs != null) {
+      final lastPrompt = DateTime.fromMillisecondsSinceEpoch(lastPromptMs);
+      final daysSince = DateTime.now().difference(lastPrompt).inDays;
+      if (daysSince < _cooldownDays) return;
+    }
+
+    // All conditions met — request review
+    await _requestReview(prefs);
+  }
+
+  Future<void> _requestReview(SharedPreferences prefs) async {
+    final isAvailable = await _inAppReview.isAvailable();
+    if (!isAvailable) return;
+
+    await _inAppReview.requestReview();
+
+    // Record timestamp so cooldown applies
+    await prefs.setInt(
+      _lastReviewPromptKey,
+      DateTime.now().millisecondsSinceEpoch,
+    );
+  }
+
+  /// For testing/debugging: reset all counters
+  Future<void> resetForTesting() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_completedSettleUpsKey);
+    await prefs.remove(_lastReviewPromptKey);
+  }
+}

--- a/lib/features/balances/screens/group_detail_screen.dart
+++ b/lib/features/balances/screens/group_detail_screen.dart
@@ -450,39 +450,41 @@ class _GroupDetailScreenState extends ConsumerState<GroupDetailScreen>
     controller.dispose();
   }
 
+  // Issue #72: 1-tap FAB for primary action (Add Expense)
+  // Secondary actions (Record Payment, Add Member) accessible via long-press.
   Widget _buildSpeedDial() {
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.end,
       children: [
-        // Speed dial options — always in tree, animated via SizeTransition
+        // Speed dial secondary options (expanded on long-press / toggle)
         _SpeedDialItem(
           icon: Icons.person_add,
           label: 'Add Member',
           onTap: _openAddMember,
           animation: _fabAnimationController,
-          index: 2,
+          index: 1,
         ),
         _SpeedDialItem(
           icon: Icons.payment,
           label: 'Record Payment',
           onTap: _openRecordPayment,
           animation: _fabAnimationController,
-          index: 1,
-        ),
-        _SpeedDialItem(
-          icon: Icons.receipt_long,
-          label: 'Add Expense',
-          onTap: _openAddExpense,
-          animation: _fabAnimationController,
           index: 0,
         ),
-        // Main FAB
-        FloatingActionButton(
-          onPressed: _toggleFab,
-          child: AnimatedIcon(
-            icon: AnimatedIcons.menu_close,
-            progress: _fabAnimationController,
+        // Main FAB — 1-tap: Add Expense; long-press: toggle secondary menu
+        GestureDetector(
+          onLongPress: _toggleFab,
+          child: FloatingActionButton.extended(
+            onPressed: _openAddExpense,
+            icon: AnimatedSwitcher(
+              duration: const Duration(milliseconds: 200),
+              child: _isFabExpanded
+                  ? const Icon(Icons.close, key: ValueKey('close'))
+                  : const Icon(Icons.add, key: ValueKey('add')),
+            ),
+            label: const Text('Add Expense'),
+            tooltip: 'Add Expense (long-press for more)',
           ),
         ),
       ],

--- a/lib/features/settlements/screens/settle_up_screen.dart
+++ b/lib/features/settlements/screens/settle_up_screen.dart
@@ -1,6 +1,9 @@
+import 'dart:async' show unawaited;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/services/notification_service.dart';
+import '../../../core/services/review_service.dart';
 import '../../../core/utils/currency_utils.dart';
 import '../../activity/services/activity_logger.dart';
 import '../../balances/models/balance.dart';
@@ -264,6 +267,10 @@ class _SettleUpScreenState extends ConsumerState<SettleUpScreen> {
         owedToName: s.toMember.name,
         groupUuid: groupId,
       );
+
+      // In-App Review: trigger after successful Settle-Up (Issue #50)
+      // ReviewService handles threshold (3 settle-ups) and 90-day cooldown.
+      unawaited(ReviewService.instance.onSettleUpCompleted());
 
       if (mounted) {
         messenger.showSnackBar(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,6 +50,7 @@ dependencies:
   pdf: ^3.11.1
   image_picker: ^1.1.2
   flutter_image_compress: ^2.3.0
+  in_app_review: ^2.0.9
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

Closes #50, #72

## In-App Review (Issue #50)

### ReviewService
New `lib/core/services/review_service.dart`:
- Tracks completed Settle-Ups via `shared_preferences`
- Triggers review prompt after **3 successful Settle-Ups** (never before first!)
- **90-day cooldown** between prompts
- Uses `in_app_review ^2.0.9` package

### Integration
`settle_up_screen.dart` calls `ReviewService.instance.onSettleUpCompleted()` after each successful settle-up (fire-and-forget via `unawaited()` — never blocks UI).

## 1-Tap FAB (Issue #72)

### Before
- User had to: 1) Tap FAB to open menu → 2) Tap 'Add Expense'

### After
- **1 tap** = directly opens Add Expense (primary action)
- **Long-press** = opens speed-dial for secondary actions (Record Payment, Add Member)
- FAB label: 'Add Expense' with tooltip hint

## Checklist
- [x] `in_app_review` package added to pubspec.yaml
- [x] ReviewService with 3-settle threshold
- [x] 90-day cooldown
- [x] Integrated in settle_up_screen.dart
- [x] 1-tap FAB opens Add Expense
- [x] Long-press for secondary menu
