### PR TITLE
fix: Replace raw error strings with user-friendly messages (Issue #74)

### DIFF
--- a/lib/core/utils/error_handler.dart
+++ b/lib/core/utils/error_handler.dart
@@ -1,0 +1,118 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+
+/// Central error handler for Split Genesis.
+/// Maps technical exceptions to user-friendly messages (DE/EN).
+class AppErrorHandler {
+  AppErrorHandler._();
+
+  /// Returns a user-friendly error message for the given [error].
+  /// Language is determined by the device locale via [context].
+  static String getMessage(dynamic error, [BuildContext? context]) {
+    final isGerman = _isGerman(context);
+
+    final err = error?.toString().toLowerCase() ?? '';
+
+    // Network / connectivity
+    if (error is SocketException ||
+        error is NetworkException ||
+        err.contains('socketexception') ||
+        err.contains('network') ||
+        err.contains('connection refused') ||
+        err.contains('no route to host') ||
+        err.contains('failed host lookup')) {
+      return isGerman
+          ? 'Keine Verbindung. Bitte prüfe dein Internet.'
+          : 'No connection. Please check your internet.';
+    }
+
+    // Timeout
+    if (error is TimeoutException ||
+        err.contains('timeout') ||
+        err.contains('timed out')) {
+      return isGerman
+          ? 'Die Anfrage hat zu lange gedauert. Bitte nochmal versuchen.'
+          : 'The request took too long. Please try again.';
+    }
+
+    // Supabase / auth errors
+    if (err.contains('invalid login') ||
+        err.contains('invalid credentials') ||
+        err.contains('email not confirmed') ||
+        err.contains('user not found') ||
+        err.contains('wrong password') ||
+        err.contains('authexception') ||
+        err.contains('auth') && err.contains('error')) {
+      return isGerman
+          ? 'Anmeldung fehlgeschlagen.'
+          : 'Sign in failed.';
+    }
+
+    // Permission / not found
+    if (err.contains('permission denied') || err.contains('403')) {
+      return isGerman
+          ? 'Keine Berechtigung für diese Aktion.'
+          : 'You don\'t have permission for this action.';
+    }
+
+    if (err.contains('not found') || err.contains('404')) {
+      return isGerman
+          ? 'Die Ressource wurde nicht gefunden.'
+          : 'The resource was not found.';
+    }
+
+    // Fallback
+    return isGerman
+        ? 'Etwas ist schiefgelaufen. Bitte App neu starten.'
+        : 'Something went wrong. Please restart the app.';
+  }
+
+  /// Shows a [SnackBar] with a user-friendly error message.
+  static void handleError(
+    dynamic error,
+    BuildContext context, {
+    Duration duration = const Duration(seconds: 4),
+  }) {
+    final message = getMessage(error, context);
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message),
+        duration: duration,
+        behavior: SnackBarBehavior.floating,
+      ),
+    );
+  }
+
+  /// Shows a user-friendly error widget (for use in `.error` builders).
+  static Widget errorWidget(dynamic error, [BuildContext? context]) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Text(
+          getMessage(error, context),
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+
+  static bool _isGerman(BuildContext? context) {
+    if (context == null) return false;
+    try {
+      final locale = Localizations.localeOf(context);
+      return locale.languageCode == 'de';
+    } catch (_) {
+      return false;
+    }
+  }
+}
+
+// Placeholder so SocketException-style check compiles on all platforms.
+class NetworkException implements Exception {
+  final String message;
+  const NetworkException(this.message);
+  @override
+  String toString() => 'NetworkException: $message';
+}

--- a/lib/features/activity/screens/activity_tab.dart
+++ b/lib/features/activity/screens/activity_tab.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/utils/error_handler.dart';
 import '../models/activity_entry.dart';
 import '../providers/activity_provider.dart';
 
@@ -137,7 +138,7 @@ class ActivityTab extends ConsumerWidget {
         );
       },
       loading: () => const Center(child: CircularProgressIndicator()),
-      error: (e, _) => Center(child: Text('Error: $e')),
+      error: (e, _) => AppErrorHandler.errorWidget(e),
     );
   }
 

--- a/lib/features/balances/screens/group_detail_screen.dart
+++ b/lib/features/balances/screens/group_detail_screen.dart
@@ -8,6 +8,7 @@ import '../../../../core/services/pdf_export_service.dart';
 import '../../../core/navigation/app_routes.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/utils/currency_utils.dart';
+import '../../../core/utils/error_handler.dart';
 import '../../../core/sync/sync_service.dart';
 import '../../../core/widgets/sync_indicator.dart';
 import '../../activity/providers/activity_provider.dart';
@@ -1111,11 +1112,11 @@ class _ExpensesTabState extends ConsumerState<_ExpensesTab> {
             );
           },
           loading: () => const Center(child: CircularProgressIndicator()),
-          error: (e, _) => Center(child: Text('Error: $e')),
+          error: (e, _) => AppErrorHandler.errorWidget(e),
         );
       },
       loading: () => const Center(child: CircularProgressIndicator()),
-      error: (error, stack) => Center(child: Text('Error: $error')),
+      error: (error, stack) => AppErrorHandler.errorWidget(error),
     );
   }
 
@@ -1539,7 +1540,7 @@ class _BalancesTab extends ConsumerWidget {
         );
       },
       loading: () => const Center(child: CircularProgressIndicator()),
-      error: (e, _) => Center(child: Text('Error: $e')),
+      error: (e, _) => AppErrorHandler.errorWidget(e),
     );
   }
 

--- a/lib/features/expenses/screens/add_expense_screen.dart
+++ b/lib/features/expenses/screens/add_expense_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/services/notification_service.dart';
+import '../../../core/utils/error_handler.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../activity/providers/activity_provider.dart';
 import '../../activity/services/activity_logger.dart';
@@ -583,7 +584,7 @@ class _AddExpenseScreenState extends ConsumerState<AddExpenseScreen> {
           );
         },
         loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => Center(child: Text('Error: $e')),
+        error: (e, _) => AppErrorHandler.errorWidget(e),
       ),
     );
   }

--- a/lib/features/expenses/screens/add_expense_wizard.dart
+++ b/lib/features/expenses/screens/add_expense_wizard.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:intl/intl.dart';
 import '../../../core/services/notification_service.dart';
+import '../../../core/utils/error_handler.dart';
 import '../../../core/services/receipt_service.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/utils/currency_utils.dart';
@@ -495,7 +496,7 @@ class _AddExpenseWizardState extends ConsumerState<AddExpenseWizard> {
           error: (e, stack) {
             debugPrint('[DEBUG] Members ERROR: $e');
             debugPrint('[DEBUG] Members STACK: $stack');
-            return Center(child: Text('Error: $e'));
+            return AppErrorHandler.errorWidget(e);
           },
         );
       },

--- a/lib/features/expenses/screens/expense_detail_screen.dart
+++ b/lib/features/expenses/screens/expense_detail_screen.dart
@@ -5,6 +5,7 @@ import 'package:uuid/uuid.dart';
 import '../../../core/database/database_helper.dart';
 import '../../../core/navigation/app_routes.dart';
 import '../../../core/utils/currency_utils.dart';
+import '../../../core/utils/error_handler.dart';
 import '../../groups/models/group.dart';
 import '../../members/providers/members_provider.dart';
 import '../models/expense.dart';
@@ -339,7 +340,7 @@ class _ExpenseDetailScreenState extends ConsumerState<ExpenseDetailScreen> {
                     },
                     loading: () =>
                         const Center(child: CircularProgressIndicator()),
-                    error: (e, _) => Text('Error: $e'),
+                    error: (e, _) => AppErrorHandler.errorWidget(e),
                   ),
                 ],
               ),

--- a/lib/features/groups/screens/home_screen.dart
+++ b/lib/features/groups/screens/home_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import '../../../core/navigation/app_routes.dart';
+import '../../../core/utils/error_handler.dart';
 import '../../../core/services/deep_link_service.dart';
 import '../../../core/services/recurring_expense_service.dart';
 import '../../../core/sync/sync_service.dart';
@@ -363,7 +364,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
           );
         },
         loading: () => const Center(child: CircularProgressIndicator()),
-        error: (error, stack) => Center(child: Text('Error: $error')),
+        error: (error, stack) => AppErrorHandler.errorWidget(error),
       ),
       floatingActionButton: FloatingActionButton.extended(
         onPressed: () {

--- a/lib/features/members/screens/manage_members_screen.dart
+++ b/lib/features/members/screens/manage_members_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../expenses/repositories/expense_repository.dart';
 import '../providers/members_provider.dart';
+import '../../../core/utils/error_handler.dart';
 
 class ManageMembersScreen extends ConsumerStatefulWidget {
   final String groupId;
@@ -186,7 +187,7 @@ class _ManageMembersScreenState extends ConsumerState<ManageMembersScreen> {
               },
               loading: () =>
                   const Center(child: CircularProgressIndicator()),
-              error: (e, _) => Center(child: Text('Error: $e')),
+              error: (e, _) => AppErrorHandler.errorWidget(e),
             ),
           ),
         ],

--- a/lib/features/settlements/screens/settle_up_screen.dart
+++ b/lib/features/settlements/screens/settle_up_screen.dart
@@ -3,6 +3,7 @@ import 'dart:async' show unawaited;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/services/notification_service.dart';
+import '../../../core/utils/error_handler.dart';
 import '../../../core/services/review_service.dart';
 import '../../../core/utils/currency_utils.dart';
 import '../../activity/services/activity_logger.dart';
@@ -294,7 +295,7 @@ class _SettleUpScreenState extends ConsumerState<SettleUpScreen> {
     } catch (e) {
       if (mounted) {
         messenger.showSnackBar(
-          SnackBar(content: Text('Error: $e')),
+          SnackBar(content: Text(AppErrorHandler.getMessage(e))),
         );
       }
     } finally {


### PR DESCRIPTION
Closes #74. No more 'Error: $e' shown to users.

## Changes
- New `AppErrorHandler` class in `lib/core/utils/error_handler.dart`
- User-friendly DE/EN messages for: NetworkException, TimeoutException, Supabase auth errors
- Fallback: 'Etwas ist schiefgelaufen. Bitte App neu starten.'
- All 8 affected screens updated: group_detail, settle_up, expense_detail, add_expense, add_expense_wizard, home, manage_members, activity_tab