### PR TITLE
redesign: Minimal UX Cleanup — CEO Feedback

### DIFF
--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -6,7 +6,16 @@ class AppTheme {
   static const Color positiveColor = Color(0xFF34C759);
   static const Color negativeColor = Color(0xFFFF3B30);
   static const Color warningColor = Color(0xFFFF9500);
-  static const Color surfaceColor = Color(0xFFF9F9F9);
+  static const Color surfaceColor = Color(0xFFF2F2F7); // iOS systemGroupedBackground
+
+  // Spacing constants
+  static const double paddingS = 8.0;
+  static const double paddingM = 16.0;
+  static const double paddingL = 24.0;
+  static const double paddingXL = 32.0;
+  static const double radiusS = 8.0;
+  static const double radiusM = 12.0;
+  static const double radiusL = 16.0;
 
   static ThemeData get theme {
     return ThemeData(
@@ -33,14 +42,14 @@ class AppTheme {
       cardTheme: CardThemeData(
         elevation: 0,
         shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(16),
+          borderRadius: BorderRadius.circular(12),
         ),
         color: Colors.white,
         surfaceTintColor: Colors.transparent,
         margin: EdgeInsets.zero,
       ),
       listTileTheme: const ListTileThemeData(
-        contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+        contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       ),
       inputDecorationTheme: InputDecorationTheme(
         filled: true,
@@ -149,14 +158,14 @@ class AppTheme {
       cardTheme: CardThemeData(
         elevation: 0,
         shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(16),
+          borderRadius: BorderRadius.circular(12),
         ),
         color: darkCard,
         surfaceTintColor: Colors.transparent,
         margin: EdgeInsets.zero,
       ),
       listTileTheme: const ListTileThemeData(
-        contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+        contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       ),
       inputDecorationTheme: InputDecorationTheme(
         filled: true,

--- a/lib/features/balances/screens/group_detail_screen.dart
+++ b/lib/features/balances/screens/group_detail_screen.dart
@@ -30,6 +30,7 @@ import '../../members/screens/manage_members_screen.dart';
 import '../../members/screens/member_detail_screen.dart';
 import '../../settlements/providers/settlements_provider.dart';
 import '../../settlements/screens/settle_up_screen.dart';
+import '../../settings/providers/settings_provider.dart';
 // settlementRecordsProvider is still needed for the "Mark as Paid" action
 
 class GroupDetailScreen extends ConsumerStatefulWidget {
@@ -1231,11 +1232,48 @@ class _BalancesTab extends ConsumerWidget {
 
   const _BalancesTab({required this.group, required this.groupId, this.currency = 'USD'});
 
+  /// Find the current user's balance based on display name match.
+  /// Returns null if no match found.
+  double? _getUserBalance(
+      String displayName, List<dynamic> balances, bool hasMultipleCurrencies,
+      List<dynamic> multiCurrencyBalances, String currency) {
+    if (displayName.trim().isEmpty) return null;
+
+    final lowerName = displayName.trim().toLowerCase();
+
+    if (!hasMultipleCurrencies) {
+      // Single-currency path
+      for (final mb in balances) {
+        if (mb.member.name.toLowerCase() == lowerName) {
+          return mb.netBalance;
+        }
+      }
+    } else {
+      // Multi-currency path: use primary currency balance
+      for (final mcb in multiCurrencyBalances) {
+        if (mcb.member.name.toLowerCase() == lowerName) {
+          return mcb.amountFor(currency);
+        }
+      }
+    }
+    return null;
+  }
+
+  String _getUserBalanceText(double? userBalance, String currency) {
+    if (userBalance == null) return '';
+    final abs = userBalance.abs();
+    final formatted = formatCurrency(abs, currency);
+    if (userBalance > 0.01) return 'You are owed $formatted';
+    if (userBalance < -0.01) return 'You owe $formatted';
+    return 'All settled up ✓';
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     debugPrint('[PERF] _BalancesTab.build() called for $groupId');
     // Single watch — all data including settlement records comes from computedData
     final computedAsync = ref.watch(groupComputedDataProvider(groupId));
+    final displayName = ref.watch(displayNameProvider);
 
     return computedAsync.when(
       data: (computed) {
@@ -1251,11 +1289,51 @@ class _BalancesTab extends ConsumerWidget {
                mcb.currencyBalances.keys.first != currency),
         );
 
+        // Hero: current user's balance (null if name not set or no match)
+        final userBalance = _getUserBalance(
+            displayName, balances, hasMultipleCurrencies,
+            multiCurrencyBalances, currency);
+
         return SingleChildScrollView(
           padding: const EdgeInsets.all(16),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
+              // ── Hero: Your Balance Card ───────────────────────────────
+              if (userBalance != null) ...[
+                Card(
+                  margin: const EdgeInsets.only(bottom: 16),
+                  child: Padding(
+                    padding: const EdgeInsets.all(20),
+                    child: Column(
+                      children: [
+                        Text(
+                          'Your Balance',
+                          style: Theme.of(context).textTheme.titleSmall
+                              ?.copyWith(color: Colors.grey),
+                        ),
+                        const SizedBox(height: 8),
+                        Text(
+                          _getUserBalanceText(userBalance, currency),
+                          style: Theme.of(context)
+                              .textTheme
+                              .displaySmall
+                              ?.copyWith(
+                                color: userBalance > 0.01
+                                    ? AppTheme.positiveColor
+                                    : userBalance < -0.01
+                                        ? AppTheme.negativeColor
+                                        : Colors.grey,
+                                fontWeight: FontWeight.bold,
+                              ),
+                          textAlign: TextAlign.center,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+              // ─────────────────────────────────────────────────────────
               // Total group spend banner
               if (totalSpend > 0)
                 Card(

--- a/lib/features/expenses/screens/add_expense_screen.dart
+++ b/lib/features/expenses/screens/add_expense_screen.dart
@@ -32,11 +32,10 @@ class _AddExpenseScreenState extends ConsumerState<AddExpenseScreen> {
   String _selectedCategory = 'general';
   String _splitType = 'equal';
   final Map<String, TextEditingController> _splitControllers = {};
+  bool _moreOptionsExpanded = false;
 
   bool get _isEditing => widget.expense != null;
   bool _saving = false;
-
-  // Categories from expense_category.dart
 
   @override
   void initState() {
@@ -48,6 +47,10 @@ class _AddExpenseScreenState extends ConsumerState<AddExpenseScreen> {
       _selectedPayerId = e.paidById;
       _selectedCategory = e.category;
       _splitType = e.splitType;
+      // If editing with non-default settings, expand more options
+      if (e.splitType != 'equal' || e.category != 'general') {
+        _moreOptionsExpanded = true;
+      }
     }
   }
 
@@ -127,7 +130,7 @@ class _AddExpenseScreenState extends ConsumerState<AddExpenseScreen> {
   }
 
   Future<void> _saveExpense() async {
-    if (_saving) return; // Double-submit guard (BUG fix)
+    if (_saving) return;
     final description = _descriptionController.text.trim();
 
     if (description.isEmpty) {
@@ -234,8 +237,7 @@ class _AddExpenseScreenState extends ConsumerState<AddExpenseScreen> {
       final perPerson = _selectedSplitMemberIds.isNotEmpty
           ? amount / _selectedSplitMemberIds.length
           : 0.0;
-      if (_selectedSplitMemberIds.isNotEmpty &&
-          _numpadAmount > 0) {
+      if (_selectedSplitMemberIds.isNotEmpty && _numpadAmount > 0) {
         return Card(
           color: Theme.of(context).colorScheme.surfaceContainerHighest,
           child: Padding(
@@ -280,7 +282,6 @@ class _AddExpenseScreenState extends ConsumerState<AddExpenseScreen> {
         hint = '0';
     }
 
-    // Calculate validation info
     double total = 0;
     for (final m in selectedMembers) {
       total += double.tryParse(_getController(m.id).text) ?? 0;
@@ -346,8 +347,8 @@ class _AddExpenseScreenState extends ConsumerState<AddExpenseScreen> {
                       contentPadding: const EdgeInsets.symmetric(
                           horizontal: 12, vertical: 10),
                     ),
-                    keyboardType: const TextInputType.numberWithOptions(
-                        decimal: true),
+                    keyboardType:
+                        const TextInputType.numberWithOptions(decimal: true),
                     onChanged: (_) => setState(() {}),
                   ),
                 ),
@@ -375,6 +376,193 @@ class _AddExpenseScreenState extends ConsumerState<AddExpenseScreen> {
     );
   }
 
+  Widget _buildMoreOptions(List<Member> members) {
+    final cat = expenseCategories.firstWhere(
+      (c) => c.key == _selectedCategory,
+      orElse: () => expenseCategories.first,
+    );
+
+    return Theme(
+      data: Theme.of(context).copyWith(dividerColor: Colors.transparent),
+      child: ExpansionTile(
+        initiallyExpanded: _moreOptionsExpanded,
+        onExpansionChanged: (v) => setState(() => _moreOptionsExpanded = v),
+        title: Row(
+          children: [
+            Icon(cat.icon, size: 16, color: cat.color),
+            const SizedBox(width: 6),
+            Text(
+              'More options',
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.primary,
+                    fontWeight: FontWeight.w500,
+                  ),
+            ),
+          ],
+        ),
+        tilePadding: EdgeInsets.zero,
+        childrenPadding: const EdgeInsets.only(top: 8),
+        children: [
+          // Category
+          Align(
+            alignment: Alignment.centerLeft,
+            child: Text('Category',
+                style: Theme.of(context).textTheme.titleSmall),
+          ),
+          const SizedBox(height: 8),
+          GridView.builder(
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 4,
+              mainAxisSpacing: 8,
+              crossAxisSpacing: 8,
+              childAspectRatio: 1.1,
+            ),
+            itemCount: expenseCategories.length,
+            itemBuilder: (context, index) {
+              final category = expenseCategories[index];
+              final isSelected = _selectedCategory == category.key;
+              return GestureDetector(
+                onTap: () => setState(() => _selectedCategory = category.key),
+                child: AnimatedContainer(
+                  duration: const Duration(milliseconds: 200),
+                  decoration: BoxDecoration(
+                    color: isSelected
+                        ? category.color.withAlpha(30)
+                        : Theme.of(context)
+                            .colorScheme
+                            .surfaceContainerHighest,
+                    borderRadius: BorderRadius.circular(12),
+                    border: Border.all(
+                      color: isSelected ? category.color : Colors.transparent,
+                      width: 2,
+                    ),
+                  ),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(category.icon, size: 22, color: category.color),
+                      const SizedBox(height: 4),
+                      Text(
+                        category.label,
+                        style: TextStyle(
+                          fontSize: 11,
+                          fontWeight: isSelected
+                              ? FontWeight.bold
+                              : FontWeight.w500,
+                          color: isSelected
+                              ? category.color
+                              : Theme.of(context).colorScheme.onSurface,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            },
+          ),
+          const SizedBox(height: 16),
+          // Paid by
+          Align(
+            alignment: Alignment.centerLeft,
+            child: Text('Paid by',
+                style: Theme.of(context).textTheme.titleSmall),
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: members.map((member) {
+              final isSelected = _selectedPayerId == member.id;
+              return ChoiceChip(
+                label: Text(member.name),
+                selected: isSelected,
+                onSelected: (selected) {
+                  setState(() {
+                    _selectedPayerId = selected ? member.id : null;
+                  });
+                },
+              );
+            }).toList(),
+          ),
+          const SizedBox(height: 16),
+          // Split type
+          Align(
+            alignment: Alignment.centerLeft,
+            child: Text('Split type',
+                style: Theme.of(context).textTheme.titleSmall),
+          ),
+          const SizedBox(height: 8),
+          SegmentedButton<String>(
+            segments: const [
+              ButtonSegment(value: 'equal', label: Text('Equal')),
+              ButtonSegment(value: 'exact', label: Text('Exact')),
+              ButtonSegment(value: 'percent', label: Text('%')),
+              ButtonSegment(value: 'shares', label: Text('Shares')),
+            ],
+            selected: {_splitType},
+            onSelectionChanged: (selected) {
+              setState(() => _splitType = selected.first);
+            },
+          ),
+          const SizedBox(height: 16),
+          // Split among
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text('Split among',
+                  style: Theme.of(context).textTheme.titleSmall),
+              TextButton(
+                onPressed: () {
+                  setState(() {
+                    if (_selectedSplitMemberIds.length == members.length) {
+                      _selectedSplitMemberIds.clear();
+                    } else {
+                      _selectedSplitMemberIds.clear();
+                      _selectedSplitMemberIds
+                          .addAll(members.map((m) => m.id));
+                    }
+                  });
+                },
+                child: Text(
+                  _selectedSplitMemberIds.length == members.length
+                      ? 'Deselect All'
+                      : 'Select All',
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: members.map((member) {
+              final isSelected = _selectedSplitMemberIds.contains(member.id);
+              return FilterChip(
+                label: Text(member.name),
+                selected: isSelected,
+                onSelected: (selected) {
+                  setState(() {
+                    if (selected) {
+                      _selectedSplitMemberIds.add(member.id);
+                    } else {
+                      _selectedSplitMemberIds.remove(member.id);
+                    }
+                  });
+                },
+              );
+            }).toList(),
+          ),
+          const SizedBox(height: 8),
+          _buildSplitInputs(members),
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final membersAsync = ref.watch(membersProvider(widget.group.id));
@@ -382,13 +570,6 @@ class _AddExpenseScreenState extends ConsumerState<AddExpenseScreen> {
     return Scaffold(
       appBar: AppBar(
         title: Text(_isEditing ? 'Edit Expense' : 'Add Expense'),
-        actions: [
-          TextButton.icon(
-            onPressed: _saveExpense,
-            icon: const Icon(Icons.check),
-            label: const Text('Save'),
-          ),
-        ],
       ),
       body: membersAsync.when(
         data: (members) {
@@ -400,8 +581,11 @@ class _AddExpenseScreenState extends ConsumerState<AddExpenseScreen> {
               WidgetsBinding.instance.addPostFrameCallback((_) {
                 if (mounted) {
                   setState(() {
-                    _selectedSplitMemberIds
-                        .addAll(members.map((m) => m.id));
+                    _selectedSplitMemberIds.addAll(members.map((m) => m.id));
+                    // Auto-set first member as default payer
+                    if (_selectedPayerId == null && members.isNotEmpty) {
+                      _selectedPayerId = members.first.id;
+                    }
                   });
                 }
               });
@@ -409,176 +593,46 @@ class _AddExpenseScreenState extends ConsumerState<AddExpenseScreen> {
           }
 
           return SingleChildScrollView(
-            padding: const EdgeInsets.all(16),
+            padding: const EdgeInsets.fromLTRB(
+                AppTheme.paddingM, AppTheme.paddingM,
+                AppTheme.paddingM, AppTheme.paddingXL),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                TextField(
-                  controller: _descriptionController,
-                  decoration: const InputDecoration(
-                    labelText: 'Description',
-                    hintText: 'e.g., Dinner, Groceries',
-                    border: OutlineInputBorder(),
-                    prefixIcon: Icon(Icons.description),
-                  ),
-                  textCapitalization: TextCapitalization.sentences,
-                ),
-                const SizedBox(height: 16),
+                // Amount numpad — primary interaction
                 AmountNumpad(
                   initialAmount: _numpadAmount,
                   onAmountChanged: (amount) {
                     setState(() => _numpadAmount = amount);
                   },
                 ),
-                const SizedBox(height: 24),
-                Text(
-                  'Category',
-                  style: Theme.of(context).textTheme.titleMedium,
-                ),
-                const SizedBox(height: 8),
-                GridView.builder(
-                  shrinkWrap: true,
-                  physics: const NeverScrollableScrollPhysics(),
-                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                    crossAxisCount: 4,
-                    mainAxisSpacing: 8,
-                    crossAxisSpacing: 8,
-                    childAspectRatio: 1.1,
+                const SizedBox(height: AppTheme.paddingM),
+                // Description — the only other required field
+                TextField(
+                  controller: _descriptionController,
+                  decoration: const InputDecoration(
+                    hintText: 'What was it for?',
+                    border: OutlineInputBorder(),
                   ),
-                  itemCount: expenseCategories.length,
-                  itemBuilder: (context, index) {
-                    final cat = expenseCategories[index];
-                    final isSelected = _selectedCategory == cat.key;
-                    return GestureDetector(
-                      onTap: () => setState(() => _selectedCategory = cat.key),
-                      child: AnimatedContainer(
-                        duration: const Duration(milliseconds: 200),
-                        decoration: BoxDecoration(
-                          color: isSelected
-                              ? cat.color.withAlpha(30)
-                              : Theme.of(context).colorScheme.surfaceContainerHighest,
-                          borderRadius: BorderRadius.circular(12),
-                          border: Border.all(
-                            color: isSelected ? cat.color : Colors.transparent,
-                            width: 2,
-                          ),
-                        ),
-                        child: Column(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            Icon(cat.icon, size: 22, color: cat.color),
-                            const SizedBox(height: 4),
-                            Text(
-                              cat.label,
-                              style: TextStyle(
-                                fontSize: 11,
-                                fontWeight: isSelected ? FontWeight.bold : FontWeight.w500,
-                                color: isSelected
-                                    ? cat.color
-                                    : Theme.of(context).colorScheme.onSurface,
-                              ),
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                          ],
-                        ),
-                      ),
-                    );
-                  },
+                  textCapitalization: TextCapitalization.sentences,
+                  autofocus: false,
                 ),
-                const SizedBox(height: 24),
-                Text(
-                  'Paid by',
-                  style: Theme.of(context).textTheme.titleMedium,
+                const SizedBox(height: AppTheme.paddingM),
+                // More options (collapsed by default)
+                _buildMoreOptions(members),
+                const SizedBox(height: AppTheme.paddingM),
+                // Primary action button
+                FilledButton(
+                  onPressed: _saving ? null : _saveExpense,
+                  child: _saving
+                      ? const SizedBox(
+                          height: 20,
+                          width: 20,
+                          child: CircularProgressIndicator(
+                              strokeWidth: 2, color: Colors.white),
+                        )
+                      : Text(_isEditing ? 'Save Changes' : 'Add Expense'),
                 ),
-                const SizedBox(height: 8),
-                Wrap(
-                  spacing: 8,
-                  runSpacing: 8,
-                  children: members.map((member) {
-                    final isSelected = _selectedPayerId == member.id;
-                    return ChoiceChip(
-                      label: Text(member.name),
-                      selected: isSelected,
-                      onSelected: (selected) {
-                        setState(() {
-                          _selectedPayerId = selected ? member.id : null;
-                        });
-                      },
-                    );
-                  }).toList(),
-                ),
-                const SizedBox(height: 24),
-                Text(
-                  'Split type',
-                  style: Theme.of(context).textTheme.titleMedium,
-                ),
-                const SizedBox(height: 8),
-                SegmentedButton<String>(
-                  segments: const [
-                    ButtonSegment(value: 'equal', label: Text('Equal')),
-                    ButtonSegment(value: 'exact', label: Text('Exact')),
-                    ButtonSegment(value: 'percent', label: Text('Percent')),
-                    ButtonSegment(value: 'shares', label: Text('Shares')),
-                  ],
-                  selected: {_splitType},
-                  onSelectionChanged: (selected) {
-                    setState(() => _splitType = selected.first);
-                  },
-                ),
-                const SizedBox(height: 16),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Text(
-                      'Split among',
-                      style: Theme.of(context).textTheme.titleMedium,
-                    ),
-                    TextButton(
-                      onPressed: () {
-                        setState(() {
-                          if (_selectedSplitMemberIds.length ==
-                              members.length) {
-                            _selectedSplitMemberIds.clear();
-                          } else {
-                            _selectedSplitMemberIds.clear();
-                            _selectedSplitMemberIds
-                                .addAll(members.map((m) => m.id));
-                          }
-                        });
-                      },
-                      child: Text(
-                        _selectedSplitMemberIds.length == members.length
-                            ? 'Deselect All'
-                            : 'Select All',
-                      ),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 8),
-                Wrap(
-                  spacing: 8,
-                  runSpacing: 8,
-                  children: members.map((member) {
-                    final isSelected =
-                        _selectedSplitMemberIds.contains(member.id);
-                    return FilterChip(
-                      label: Text(member.name),
-                      selected: isSelected,
-                      onSelected: (selected) {
-                        setState(() {
-                          if (selected) {
-                            _selectedSplitMemberIds.add(member.id);
-                          } else {
-                            _selectedSplitMemberIds.remove(member.id);
-                          }
-                        });
-                      },
-                    );
-                  }).toList(),
-                ),
-                const SizedBox(height: 16),
-                _buildSplitInputs(members),
               ],
             ),
           );
@@ -589,4 +643,3 @@ class _AddExpenseScreenState extends ConsumerState<AddExpenseScreen> {
     );
   }
 }
-

--- a/lib/features/groups/screens/home_screen.dart
+++ b/lib/features/groups/screens/home_screen.dart
@@ -239,7 +239,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
             itemBuilder: (context, index) {
               final group = groups[index];
               return Padding(
-                padding: const EdgeInsets.only(bottom: 12),
+                padding: const EdgeInsets.only(bottom: 8),
                 child: Card(
                   child: Tooltip(
                     message: 'Hold to delete group',


### PR DESCRIPTION
## Summary

CEO Feedback: *"überfüllt, unübersichtlich, Eintragen-Prozess soll massiv minimal und vereinfacht sein"*

---

## Changes

### CHANGE 1 — `app_theme.dart`: Spacing & Sizing

- **surfaceColor**: `#F9F9F9` → `#F2F2F7` (authentic iOS `systemGroupedBackground`)
- **cardTheme borderRadius**: `16` → `12` (more consistent, less Material-y)
- **listTileTheme** contentPadding vertical: `4` → `8` (more breathing room)
- **New spacing constants**: `paddingS/M/L/XL` + `radiusS/M/L` for consistent layout

### CHANGE 2 — `add_expense_screen.dart`: Massive Simplification ⭐

**Before:** Full screen with 8 category chips, payer chips, 4 split-type buttons all visible at once.

**After:** 3 elements only:
1. Numpad (amount)
2. TextField ("What was it for?")
3. "Add Expense" button

Advanced options (Category / Paid by / Split type / Split among) hidden in a collapsed **"More options"** ExpansionTile — visible only when needed.

- Default: equal split, first member auto-selected as payer
- Edit mode: auto-expands "More options" when non-default values detected
- **All business logic preserved** — only UI is reduced

### CHANGE 3 — `group_detail_screen.dart`: Balances Hero Card

In the **Balances** tab, a new hero card shows the current user's personal balance at the top:
- *"You are owed €X"* (green) / *"You owe €X"* (red) / *"All settled up ✓"* (grey)
- Matches against `displayName` from settings
- Hidden if display name is not set or no member match found

### CHANGE 4 — `home_screen.dart`: Group Card Spacing

- Reduced gap between group cards: `12px` → `8px` (tighter, cleaner list)

---

## Notes

- No business logic changed — purely UI/UX
- `flutter analyze` requires on-device verification (no toolchain on CI server)
- PR is ready for CEO review