### PR TITLE
feat: Apple-like UX Redesign (MainShell Tab Bar, CupertinoActionSheets, 3-page Onboarding)

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'core/navigation/main_shell.dart';
 import 'core/services/deep_link_service.dart';
 import 'core/theme/app_theme.dart';
-import 'features/groups/screens/home_screen.dart';
 import 'features/onboarding/providers/onboarding_provider.dart';
 import 'features/onboarding/screens/onboarding_screen.dart';
 import 'features/settings/providers/settings_provider.dart';
@@ -36,14 +36,14 @@ class SplitGenesisApp extends ConsumerWidget {
         data: (completed) {
           // Skip onboarding if deep link is present or already completed
           if (completed || DeepLinkService.instance.initialCode != null) {
-            return const HomeScreen();
+            return const MainShell();
           }
           return const OnboardingScreen();
         },
         loading: () => const Scaffold(
           body: Center(child: CircularProgressIndicator()),
         ),
-        error: (_, __) => const HomeScreen(),
+        error: (_, __) => const MainShell(),
       ),
       debugShowCheckedModeBanner: false,
     );

--- a/lib/core/navigation/main_shell.dart
+++ b/lib/core/navigation/main_shell.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import '../../features/activity/screens/global_activity_screen.dart';
+import '../../features/groups/screens/home_screen.dart';
+import '../../features/settings/screens/settings_screen.dart';
+
+class MainShell extends StatefulWidget {
+  const MainShell({super.key});
+
+  @override
+  State<MainShell> createState() => _MainShellState();
+}
+
+class _MainShellState extends State<MainShell> {
+  int _selectedIndex = 0;
+
+  static const List<Widget> _pages = [
+    HomeScreen(),
+    GlobalActivityScreen(),
+    SettingsScreen(),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: IndexedStack(
+        index: _selectedIndex,
+        children: _pages,
+      ),
+      bottomNavigationBar: NavigationBar(
+        selectedIndex: _selectedIndex,
+        onDestinationSelected: (index) {
+          setState(() => _selectedIndex = index);
+        },
+        destinations: const [
+          NavigationDestination(
+            icon: Icon(Icons.home_outlined),
+            selectedIcon: Icon(Icons.home),
+            label: 'Groups',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.access_time_outlined),
+            selectedIcon: Icon(Icons.access_time_filled),
+            label: 'Activity',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.person_outline),
+            selectedIcon: Icon(Icons.person),
+            label: 'Profile',
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/activity/screens/global_activity_screen.dart
+++ b/lib/features/activity/screens/global_activity_screen.dart
@@ -1,0 +1,155 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/utils/error_handler.dart';
+import '../models/activity_entry.dart';
+import '../providers/activity_provider.dart';
+import '../../groups/providers/groups_provider.dart';
+
+class GlobalActivityScreen extends ConsumerWidget {
+  const GlobalActivityScreen({super.key});
+
+  static const _typeIcons = <ActivityType, IconData>{
+    ActivityType.expenseCreated: Icons.add_circle,
+    ActivityType.expenseUpdated: Icons.edit,
+    ActivityType.expenseDeleted: Icons.delete,
+    ActivityType.settlementRecorded: Icons.arrow_forward,
+    ActivityType.settlementDeleted: Icons.remove_circle,
+    ActivityType.memberAdded: Icons.person_add,
+    ActivityType.memberRemoved: Icons.person_remove,
+    ActivityType.groupCreated: Icons.group,
+    ActivityType.groupRenamed: Icons.edit_note,
+    ActivityType.memberJoined: Icons.person_add_alt,
+  };
+
+  static const _typeColors = <ActivityType, Color>{
+    ActivityType.expenseCreated: Colors.blue,
+    ActivityType.expenseUpdated: Colors.orange,
+    ActivityType.expenseDeleted: Colors.red,
+    ActivityType.settlementRecorded: AppTheme.positiveColor,
+    ActivityType.settlementDeleted: Colors.red,
+    ActivityType.memberAdded: Colors.green,
+    ActivityType.memberRemoved: Colors.red,
+    ActivityType.groupCreated: Colors.purple,
+    ActivityType.groupRenamed: Colors.orange,
+    ActivityType.memberJoined: Colors.green,
+  };
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final groupsAsync = ref.watch(groupsProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Activity'),
+      ),
+      body: groupsAsync.when(
+        data: (groups) {
+          if (groups.isEmpty) {
+            return Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    Icons.access_time,
+                    size: 64,
+                    color: Theme.of(context).colorScheme.onSurface.withAlpha(80),
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    'No activity yet',
+                    style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                          color: Theme.of(context).colorScheme.onSurface.withAlpha(150),
+                        ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Create a group to get started',
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          color: Theme.of(context).colorScheme.onSurface.withAlpha(100),
+                        ),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          // Combine activity from all groups
+          final allActivities = groups
+              .map((g) => ref.watch(activityProvider(g.id)))
+              .toList();
+
+          final isLoading = allActivities.any((a) => a.isLoading);
+          if (isLoading) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          final combined = <ActivityEntry>[];
+          for (final a in allActivities) {
+            a.whenData((list) => combined.addAll(list));
+          }
+
+          // Sort by timestamp descending
+          combined.sort((a, b) => b.timestamp.compareTo(a.timestamp));
+
+          if (combined.isEmpty) {
+            return Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    Icons.access_time,
+                    size: 64,
+                    color: Theme.of(context).colorScheme.onSurface.withAlpha(80),
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    'No activity yet',
+                    style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                          color: Theme.of(context).colorScheme.onSurface.withAlpha(150),
+                        ),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          return ListView.builder(
+            padding: const EdgeInsets.symmetric(vertical: 8),
+            itemCount: combined.length,
+            itemBuilder: (context, index) {
+              final entry = combined[index];
+              final icon = _typeIcons[entry.type] ?? Icons.info_outline;
+              final color = _typeColors[entry.type] ?? Colors.grey;
+              // Find group name
+              final groupName = groups
+                  .where((g) => g.id == entry.groupId)
+                  .map((g) => g.name)
+                  .firstOrNull;
+
+              return ListTile(
+                leading: CircleAvatar(
+                  backgroundColor: color.withAlpha(30),
+                  child: Icon(icon, color: color, size: 20),
+                ),
+                title: Text(entry.description),
+                subtitle: Text(
+                  [
+                    if (groupName != null) groupName,
+                    DateFormat.MMMd().add_jm().format(entry.timestamp),
+                  ].join(' · '),
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Theme.of(context).colorScheme.onSurface.withAlpha(120),
+                      ),
+                ),
+              );
+            },
+          );
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => AppErrorHandler.errorWidget(e),
+      ),
+    );
+  }
+}

--- a/lib/features/balances/screens/group_detail_screen.dart
+++ b/lib/features/balances/screens/group_detail_screen.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -1142,23 +1143,30 @@ class _ExpensesTabState extends ConsumerState<_ExpensesTab> {
         child: const Icon(Icons.delete, color: Colors.white),
       ),
       confirmDismiss: (_) async {
-        final confirmed = await showDialog<bool>(
+        bool? confirmed;
+        await showCupertinoModalPopup<void>(
           context: context,
-          builder: (ctx) => AlertDialog(
+          builder: (ctx) => CupertinoActionSheet(
             title: const Text('Delete Expense'),
-            content: Text(
-                'Delete "${expense.description}" (\$${expense.amount.toStringAsFixed(2)})?'),
+            message: Text(
+                '"${expense.description}" (${expense.amount.toStringAsFixed(2)}) will be permanently deleted.'),
             actions: [
-              TextButton(
-                onPressed: () => Navigator.pop(ctx, false),
-                child: const Text('Cancel'),
-              ),
-              TextButton(
-                onPressed: () => Navigator.pop(ctx, true),
-                child: const Text('Delete',
-                    style: TextStyle(color: Colors.red)),
+              CupertinoActionSheetAction(
+                isDestructiveAction: true,
+                onPressed: () {
+                  confirmed = true;
+                  Navigator.pop(ctx);
+                },
+                child: const Text('Delete Expense'),
               ),
             ],
+            cancelButton: CupertinoActionSheetAction(
+              onPressed: () {
+                confirmed = false;
+                Navigator.pop(ctx);
+              },
+              child: const Text('Cancel'),
+            ),
           ),
         );
         if (confirmed == true) {
@@ -1568,22 +1576,29 @@ class _BalancesTab extends ConsumerWidget {
                         height: 36,
                         child: FilledButton.tonalIcon(
                         onPressed: () async {
-                          final confirmed = await showDialog<bool>(
+                          bool? confirmed;
+                          await showCupertinoModalPopup<void>(
                             context: context,
-                            builder: (ctx) => AlertDialog(
+                            builder: (ctx) => CupertinoActionSheet(
                               title: const Text('Mark as Paid'),
-                              content: Text(
+                              message: Text(
                                   '${s.fromMember.name} paid ${formatCurrency(s.amount, currency)} to ${s.toMember.name}?'),
                               actions: [
-                                TextButton(
-                                  onPressed: () => Navigator.pop(ctx, false),
-                                  child: const Text('Cancel'),
-                                ),
-                                TextButton(
-                                  onPressed: () => Navigator.pop(ctx, true),
-                                  child: const Text('Confirm'),
+                                CupertinoActionSheetAction(
+                                  onPressed: () {
+                                    confirmed = true;
+                                    Navigator.pop(ctx);
+                                  },
+                                  child: const Text('Confirm Payment'),
                                 ),
                               ],
+                              cancelButton: CupertinoActionSheetAction(
+                                onPressed: () {
+                                  confirmed = false;
+                                  Navigator.pop(ctx);
+                                },
+                                child: const Text('Cancel'),
+                              ),
                             ),
                           );
                           if (confirmed == true) {

--- a/lib/features/groups/screens/home_screen.dart
+++ b/lib/features/groups/screens/home_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
@@ -9,7 +10,6 @@ import '../../../core/services/recurring_expense_service.dart';
 import '../../../core/sync/sync_service.dart';
 import '../../../core/widgets/sync_indicator.dart';
 import '../../../core/utils/currency_utils.dart';
-import '../../settings/screens/settings_screen.dart';
 import '../models/group_type.dart';
 import '../providers/groups_provider.dart';
 import '../providers/group_summary_provider.dart';
@@ -168,16 +168,6 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
             tooltip: 'Join group',
             onPressed: _showJoinGroupDialog,
           ),
-          IconButton(
-            icon: const Icon(Icons.settings_outlined),
-            tooltip: 'Settings',
-            onPressed: () {
-              Navigator.push(
-                context,
-                slideRoute(const SettingsScreen()),
-              );
-            },
-          ),
         ],
       ),
       body: groupsAsync.when(
@@ -258,28 +248,28 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                       debugPrint('[PERF] HomeScreen: Navigator.push called at ${sw.elapsedMilliseconds}ms');
                     },
                     onLongPress: () {
-                      showDialog(
+                      showCupertinoModalPopup<void>(
                         context: context,
-                        builder: (ctx) => AlertDialog(
+                        builder: (ctx) => CupertinoActionSheet(
                           title: const Text('Delete Group'),
-                          content: Text(
-                              'Delete "${group.name}" and all its expenses?'),
+                          message: Text(
+                              'Delete "${group.name}" and all its expenses? This cannot be undone.'),
                           actions: [
-                            TextButton(
-                              onPressed: () => Navigator.pop(ctx),
-                              child: const Text('Cancel'),
-                            ),
-                            TextButton(
+                            CupertinoActionSheetAction(
+                              isDestructiveAction: true,
                               onPressed: () {
+                                Navigator.pop(ctx);
                                 ref
                                     .read(groupsProvider.notifier)
                                     .deleteGroup(group.id);
-                                Navigator.pop(ctx);
                               },
-                              child: const Text('Delete',
-                                  style: TextStyle(color: Colors.red)),
+                              child: const Text('Delete Group'),
                             ),
                           ],
+                          cancelButton: CupertinoActionSheetAction(
+                            onPressed: () => Navigator.pop(ctx),
+                            child: const Text('Cancel'),
+                          ),
                         ),
                       );
                     },

--- a/lib/features/members/screens/manage_members_screen.dart
+++ b/lib/features/members/screens/manage_members_screen.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../expenses/repositories/expense_repository.dart';
@@ -47,22 +48,29 @@ class _ManageMembersScreenState extends ConsumerState<ManageMembersScreen> {
       return;
     }
 
-    final confirmed = await showDialog<bool>(
+    bool? confirmed;
+    await showCupertinoModalPopup<void>(
       context: context,
-      builder: (ctx) => AlertDialog(
+      builder: (ctx) => CupertinoActionSheet(
         title: const Text('Remove Member'),
-        content: Text('Remove "$memberName" from this group?'),
+        message: Text('Remove "$memberName" from this group?'),
         actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            child:
-                const Text('Remove', style: TextStyle(color: Colors.red)),
+          CupertinoActionSheetAction(
+            isDestructiveAction: true,
+            onPressed: () {
+              confirmed = true;
+              Navigator.pop(ctx);
+            },
+            child: const Text('Remove Member'),
           ),
         ],
+        cancelButton: CupertinoActionSheetAction(
+          onPressed: () {
+            confirmed = false;
+            Navigator.pop(ctx);
+          },
+          child: const Text('Cancel'),
+        ),
       ),
     );
 

--- a/lib/features/onboarding/screens/onboarding_screen.dart
+++ b/lib/features/onboarding/screens/onboarding_screen.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/onboarding_provider.dart';
 import '../../settings/providers/settings_provider.dart';
-import '../../groups/screens/home_screen.dart';
+import '../../../core/navigation/main_shell.dart';
 
 class OnboardingScreen extends ConsumerStatefulWidget {
   const OnboardingScreen({super.key});
@@ -17,7 +17,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
   bool _isSubmitting = false;
   int _currentPage = 0;
 
-  static const int _totalPages = 4;
+  static const int _totalPages = 3;
 
   @override
   void dispose() {
@@ -38,7 +38,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
     if (mounted) {
       Navigator.pushReplacement(
         context,
-        MaterialPageRoute(builder: (_) => const HomeScreen()),
+        MaterialPageRoute(builder: (_) => const MainShell()),
       );
     }
   }
@@ -86,7 +86,6 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
                 onPageChanged: (i) => setState(() => _currentPage = i),
                 children: [
                   _WelcomePage(onNext: _nextPage),
-                  _OfflineFirstPage(onNext: _nextPage),
                   _SettleUpUSPPage(onNext: _nextPage),
                   _GetStartedPage(
                     nameController: _nameController,

--- a/lib/features/settlements/screens/settle_up_screen.dart
+++ b/lib/features/settlements/screens/settle_up_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:async' show unawaited;
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/services/notification_service.dart';
@@ -175,59 +176,31 @@ class _SettleUpScreenState extends ConsumerState<SettleUpScreen> {
     // Capture messenger before any async gap
     final messenger = ScaffoldMessenger.of(context);
 
-    // Confirmation dialog
-    final confirmed = await showDialog<bool>(
+    // Confirmation action sheet
+    bool? confirmed;
+    await showCupertinoModalPopup<void>(
       context: context,
-      builder: (ctx) => AlertDialog(
-        icon: const Icon(Icons.check_circle_outline, color: Colors.green, size: 40),
+      builder: (ctx) => CupertinoActionSheet(
         title: const Text('Mark as Settled'),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            RichText(
-              textAlign: TextAlign.center,
-              text: TextSpan(
-                style: Theme.of(ctx).textTheme.bodyMedium,
-                children: [
-                  TextSpan(
-                    text: s.fromMember.name,
-                    style: const TextStyle(fontWeight: FontWeight.bold),
-                  ),
-                  const TextSpan(text: ' paid '),
-                  TextSpan(
-                    text: formatCurrency(s.amount, widget.group.currency),
-                    style: const TextStyle(fontWeight: FontWeight.bold),
-                  ),
-                  const TextSpan(text: ' to '),
-                  TextSpan(
-                    text: s.toMember.name,
-                    style: const TextStyle(fontWeight: FontWeight.bold),
-                  ),
-                  const TextSpan(text: '.'),
-                ],
-              ),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              'This will update the group balances.',
-              style: Theme.of(ctx).textTheme.bodySmall?.copyWith(
-                    color: Theme.of(ctx).colorScheme.onSurface.withAlpha(150),
-                  ),
-              textAlign: TextAlign.center,
-            ),
-          ],
+        message: Text(
+          '${s.fromMember.name} paid ${formatCurrency(s.amount, widget.group.currency)} to ${s.toMember.name}.\nThis will update the group balances.',
         ),
         actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton.icon(
-            onPressed: () => Navigator.pop(ctx, true),
-            icon: const Icon(Icons.check, size: 16),
-            label: const Text('Confirm'),
+          CupertinoActionSheetAction(
+            onPressed: () {
+              confirmed = true;
+              Navigator.pop(ctx);
+            },
+            child: const Text('Confirm Payment'),
           ),
         ],
+        cancelButton: CupertinoActionSheetAction(
+          onPressed: () {
+            confirmed = false;
+            Navigator.pop(ctx);
+          },
+          child: const Text('Cancel'),
+        ),
       ),
     );
 


### PR DESCRIPTION
## Summary

Apple-like UX improvements for Splitty — 3 steps implemented.

---

## STEP 1 — Bottom Navigation Bar (Tab Bar)

- ✅ Added `lib/core/navigation/main_shell.dart` with Material 3 `NavigationBar`
  - 3 tabs: **Groups** (home icon), **Activity** (clock icon), **Profile** (person icon)
  - `IndexedStack` preserves state when switching tabs
- ✅ `lib/app.dart`: `home: MainShell()` instead of `HomeScreen()`
- ✅ `onboarding_screen.dart`: navigates to `MainShell` after completion
- ✅ `home_screen.dart`: Settings icon removed from AppBar (now accessible via Tab 3)
- ✅ Created `GlobalActivityScreen` for Tab 2 (aggregates activity from all groups)

## STEP 2 — iOS Action Sheets instead of Material Dialogs

Replaced all destructive `showDialog` calls with `showCupertinoModalPopup` + `CupertinoActionSheet`:

| File | Action |
|------|--------|
| `home_screen.dart` | Delete group (long-press) |
| `group_detail_screen.dart` | Delete expense (swipe), Mark as paid |
| `settle_up_screen.dart` | Mark as settled |
| `manage_members_screen.dart` | Remove member |

Non-destructive input dialogs (Rename Group, Record Payment, Join Group, Add Member) remain as `AlertDialog`.

Added `import 'package:flutter/cupertino.dart';` to all affected files.

## STEP 3 — Onboarding reduced to 3 pages

- `_totalPages = 3` (was 4)
- Removed `_OfflineFirstPage` (wifi/offline-first page)
- Flow: **Welcome** → **Settle-Up USP** (with `_DebtSimplificationDiagram`) → **Get Started**

---

## Notes

- Flutter is not installed on CI server, so `flutter analyze` could not be run locally. Code reviewed manually for type safety and import correctness.
- `GlobalActivityScreen` uses `groupsProvider` + `activityProvider` per group to aggregate recent activity across all groups.