### PR TITLE
feat: Home Screen - Balance on Group Cards (#92)

### DIFF
--- a/lib/features/balances/providers/balances_provider.dart
+++ b/lib/features/balances/providers/balances_provider.dart
@@ -7,6 +7,7 @@ import '../../members/providers/members_provider.dart';
 import '../../settlements/models/settlement_record.dart';
 import '../../settlements/providers/settlements_provider.dart';
 import '../../expenses/models/expense.dart';
+import '../../settings/providers/settings_provider.dart';
 import '../models/balance.dart';
 import '../services/debt_calculator.dart';
 
@@ -129,4 +130,79 @@ final settlementsProvider =
     FutureProvider.family<List<Settlement>, String>((ref, groupId) async {
   final data = await ref.watch(groupComputedDataProvider(groupId).future);
   return data.settlements;
+});
+
+/// Enum representing the current user's balance status in a group.
+enum UserBalanceStatus { positive, negative, settled, unknown }
+
+/// User balance result for a specific group.
+class GroupUserBalance {
+  final double? amount; // null if name not set or no match
+  final UserBalanceStatus status;
+  final String currency;
+
+  const GroupUserBalance({
+    required this.amount,
+    required this.status,
+    required this.currency,
+  });
+
+  bool get isKnown => amount != null;
+}
+
+/// Provider that computes the current user's net balance in a group.
+/// Watches groupComputedDataProvider + displayNameProvider.
+final groupUserBalanceProvider =
+    FutureProvider.family<GroupUserBalance, String>((ref, groupId) async {
+  final computed = await ref.watch(groupComputedDataProvider(groupId).future);
+  final displayName = ref.watch(displayNameProvider);
+  
+  // Get the group currency from groups provider
+  final groups = ref.read(groupsProvider).valueOrNull ?? [];
+  final group = groups.firstWhere(
+    (g) => g.id == groupId,
+    orElse: () => throw StateError('Group $groupId not found'),
+  );
+  final currency = group.currency;
+
+  if (displayName.trim().isEmpty) {
+    return GroupUserBalance(amount: null, status: UserBalanceStatus.unknown, currency: currency);
+  }
+
+  final lowerName = displayName.trim().toLowerCase();
+  final hasMultipleCurrencies = computed.multiCurrencyBalances.any(
+    (mcb) => mcb.currencyBalances.length > 1 ||
+        (mcb.currencyBalances.isNotEmpty &&
+         mcb.currencyBalances.keys.first != currency),
+  );
+
+  double? balance;
+
+  if (!hasMultipleCurrencies) {
+    for (final mb in computed.balances) {
+      if (mb.member.name.toLowerCase() == lowerName) {
+        balance = mb.netBalance;
+        break;
+      }
+    }
+  } else {
+    for (final mcb in computed.multiCurrencyBalances) {
+      if (mcb.member.name.toLowerCase() == lowerName) {
+        balance = mcb.amountFor(currency);
+        break;
+      }
+    }
+  }
+
+  if (balance == null) {
+    return GroupUserBalance(amount: null, status: UserBalanceStatus.unknown, currency: currency);
+  }
+
+  final status = balance > 0.01
+      ? UserBalanceStatus.positive
+      : balance < -0.01
+          ? UserBalanceStatus.negative
+          : UserBalanceStatus.settled;
+
+  return GroupUserBalance(amount: balance, status: status, currency: currency);
 });

--- a/lib/features/groups/screens/home_screen.dart
+++ b/lib/features/groups/screens/home_screen.dart
@@ -10,6 +10,7 @@ import '../../../core/services/recurring_expense_service.dart';
 import '../../../core/sync/sync_service.dart';
 import '../../../core/widgets/sync_indicator.dart';
 import '../../../core/utils/currency_utils.dart';
+import '../../../core/theme/app_theme.dart';
 import '../models/group_type.dart';
 import '../providers/groups_provider.dart';
 import '../providers/group_summary_provider.dart';
@@ -17,6 +18,7 @@ import 'add_group_screen.dart';
 import '../../../l10n/app_localizations.dart';
 import 'join_group_screen.dart';
 import '../../balances/screens/group_detail_screen.dart';
+import '../../balances/providers/balances_provider.dart';
 
 class HomeScreen extends ConsumerStatefulWidget {
   const HomeScreen({super.key});
@@ -333,6 +335,44 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                                     );
                                   },
                                 ),
+                              // User balance badge
+                              Consumer(
+                                builder: (context, ref, _) {
+                                  final balanceAsync = ref.watch(
+                                      groupUserBalanceProvider(group.id));
+                                  return balanceAsync.when(
+                                    data: (ub) {
+                                      if (!ub.isKnown) return const SizedBox();
+                                      final amount = ub.amount!;
+                                      final absAmount = amount.abs();
+                                      Color color;
+                                      String label;
+                                      if (ub.status == UserBalanceStatus.positive) {
+                                        color = AppTheme.positiveColor;
+                                        label = 'owed ${formatCurrency(absAmount, ub.currency)}';
+                                      } else if (ub.status == UserBalanceStatus.negative) {
+                                        color = AppTheme.negativeColor;
+                                        label = 'owe ${formatCurrency(absAmount, ub.currency)}';
+                                      } else {
+                                        color = Colors.grey;
+                                        label = 'settled';
+                                      }
+                                      return Text(
+                                        label,
+                                        style: Theme.of(context)
+                                            .textTheme
+                                            .bodySmall
+                                            ?.copyWith(
+                                              color: color,
+                                              fontWeight: FontWeight.w600,
+                                            ),
+                                      );
+                                    },
+                                    loading: () => const SizedBox(),
+                                    error: (_, __) => const SizedBox(),
+                                  );
+                                },
+                              ),
                               ],
                             ),
                           ),
@@ -356,19 +396,16 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (error, stack) => AppErrorHandler.errorWidget(error),
       ),
-      floatingActionButton: FloatingActionButton.extended(
+      floatingActionButton: FloatingActionButton(
         onPressed: () {
           Navigator.push(
             context,
             slideRoute(const AddGroupScreen()),
           );
         },
-        icon: const Icon(Icons.add),
-        label: const Text('New Group'),
-        extendedPadding: const EdgeInsets.symmetric(horizontal: 24),
-        shape: const StadiumBorder(),
+        tooltip: 'New Group',
+        child: const Icon(Icons.add),
       ),
-      floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
     );
   }
 }


### PR DESCRIPTION
## Summary

Part of the Splitty UX Roadmap (Issue #91 roadmap, iteration #92).

## Changes

### 1. groupUserBalanceProvider
New Riverpod provider in `balances_provider.dart`:
- Combines `groupComputedDataProvider` + `displayNameProvider`
- Returns `GroupUserBalance` with amount, status (positive/negative/settled/unknown) and currency
- Handles both single-currency and multi-currency paths
- Returns `unknown` status if display name not set or no member match

### 2. User Balance on Group Cards
Each group card in the home screen now shows the user's balance:
- 🟢 **"owed €X"** — someone owes you (green)
- 🔴 **"owe €X"** — you owe someone (red)
- ⚪ **"settled"** — all settled up (grey)
- Hidden when display name not set or no match

### 3. Simplified FAB
- Changed from `FloatingActionButton.extended` to plain `FloatingActionButton`
- Removed `centerFloat` location (back to default bottom-right)
- Cleaner, less visually dominant