### PR TITLE
redesign(typography): Spacing Audit + Shared SectionHeader — Iteration 5

### DIFF
--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -17,6 +17,14 @@ class AppTheme {
   static const double radiusM = 12.0;
   static const double radiusL = 16.0;
 
+  // Opacity constants (use with Color.withAlpha)
+  static const double subtleAlpha = 80 / 255;
+  static const double secondaryAlpha = 130 / 255;
+
+  // Shared padding
+  static const EdgeInsets horizontalPadding =
+      EdgeInsets.symmetric(horizontal: 16);
+
   static ThemeData get theme {
     return ThemeData(
       colorScheme: ColorScheme.fromSeed(

--- a/lib/core/widgets/section_header.dart
+++ b/lib/core/widgets/section_header.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+
+/// Shared iOS-style section header widget.
+///
+/// Renders an uppercase label with an optional icon, matching the
+/// iOS Settings / grouped list section header pattern.
+class SectionHeader extends StatelessWidget {
+  const SectionHeader({
+    super.key,
+    required this.label,
+    this.icon,
+    this.padding = const EdgeInsets.only(left: 4, bottom: 8),
+  });
+
+  final String label;
+  final IconData? icon;
+  final EdgeInsets padding;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    return Padding(
+      padding: padding,
+      child: Row(
+        children: [
+          if (icon != null) ...[
+            Icon(
+              icon,
+              size: 16,
+              color: colorScheme.primary,
+            ),
+            const SizedBox(width: 6),
+          ],
+          Text(
+            label.toUpperCase(),
+            style: textTheme.labelSmall?.copyWith(
+              color: colorScheme.primary,
+              fontWeight: FontWeight.w700,
+              letterSpacing: 0.8,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/expenses/screens/statistics_screen.dart
+++ b/lib/features/expenses/screens/statistics_screen.dart
@@ -54,16 +54,13 @@ class _StatisticsScreenState extends ConsumerState<StatisticsScreen> {
           children: [
             Text(
               'Statistics',
-              style: TextStyle(
-                fontSize: 17,
-                fontWeight: FontWeight.w600,
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
                 color: Theme.of(context).colorScheme.onSurface,
               ),
             ),
             Text(
               widget.groupName,
-              style: TextStyle(
-                fontSize: 12,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
                 fontWeight: FontWeight.w400,
                 color: Theme.of(context).colorScheme.onSurface.withAlpha(150),
               ),
@@ -353,9 +350,8 @@ class _TotalSpendCard extends StatelessWidget {
           const SizedBox(height: 16),
           Text(
             formatted,
-            style: const TextStyle(
+            style: Theme.of(context).textTheme.displaySmall?.copyWith(
               color: Colors.white,
-              fontSize: 36,
               fontWeight: FontWeight.w700,
               letterSpacing: -0.5,
             ),
@@ -764,9 +760,7 @@ class _SectionHeader extends StatelessWidget {
         const SizedBox(width: 10),
         Text(
           title,
-          style: TextStyle(
-            fontSize: 15,
-            fontWeight: FontWeight.w600,
+          style: Theme.of(context).textTheme.titleSmall?.copyWith(
             color: Theme.of(context).colorScheme.onSurface,
           ),
         ),


### PR DESCRIPTION
## Typography + Spacing Audit

### Changes

#### `lib/core/theme/app_theme.dart`
- Added: `static const double subtleAlpha = 80 / 255;`
- Added: `static const double secondaryAlpha = 130 / 255;`
- Added: `static const EdgeInsets horizontalPadding = EdgeInsets.symmetric(horizontal: 16);`

#### `lib/core/widgets/section_header.dart` (NEW)
- Shared `SectionHeader` widget — iOS grouped list section header (uppercase, icon, primary color)

#### `lib/features/expenses/screens/statistics_screen.dart`
- AppBar title: hardcoded `fontSize: 17` → `textTheme.titleMedium`
- AppBar subtitle: hardcoded `fontSize: 12` → `textTheme.bodySmall`
- Total amount: hardcoded `fontSize: 36` → `textTheme.displaySmall` (keeps `letterSpacing: -0.5`)
- Section header: hardcoded `fontSize: 15` → `textTheme.titleSmall`

Part of UX Iteration Round 2.