### PR TITLE
UX Iter 18: Micro-interactions + Polish — Spring Cards, Semantic Transitions, Staggered Entrance

### DIFF
--- a/lib/core/navigation/app_routes.dart
+++ b/lib/core/navigation/app_routes.dart
@@ -1,15 +1,94 @@
 import 'package:flutter/material.dart';
 
-Route<T> slideRoute<T>(Widget page) {
+// ─────────────────────────────────────────────────────────────────────────────
+// Route Transitions — Splitty Navigation System
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Slide-from-right (legacy, still used where explicit slide is desired)
+Route<T> slideRoute<T>(Widget page, {Duration? duration}) {
   return PageRouteBuilder<T>(
     pageBuilder: (context, animation, secondaryAnimation) => page,
     transitionsBuilder: (context, animation, secondaryAnimation, child) {
-      const begin = Offset(1.0, 0.0);
-      const end = Offset.zero;
-      final tween =
-          Tween(begin: begin, end: end).chain(CurveTween(curve: Curves.easeInOut));
+      final tween = Tween(
+        begin: const Offset(1.0, 0.0),
+        end: Offset.zero,
+      ).chain(CurveTween(curve: Curves.easeInOutCubic));
       return SlideTransition(position: animation.drive(tween), child: child);
     },
-    transitionDuration: const Duration(milliseconds: 300),
+    transitionDuration: duration ?? const Duration(milliseconds: 350),
+    reverseTransitionDuration: duration ?? const Duration(milliseconds: 300),
+  );
+}
+
+/// Fade transition — for detail screens and modals
+Route<T> fadeRoute<T>(Widget page, {Duration? duration}) {
+  return PageRouteBuilder<T>(
+    pageBuilder: (context, animation, secondaryAnimation) => page,
+    transitionsBuilder: (context, animation, secondaryAnimation, child) {
+      return FadeTransition(
+        opacity: CurvedAnimation(parent: animation, curve: Curves.easeInOut),
+        child: child,
+      );
+    },
+    transitionDuration: duration ?? const Duration(milliseconds: 280),
+    reverseTransitionDuration: duration ?? const Duration(milliseconds: 220),
+  );
+}
+
+/// Shared-axis horizontal — for top-level navigation transitions (Material You)
+Route<T> sharedAxisRoute<T>(Widget page, {Duration? duration}) {
+  return PageRouteBuilder<T>(
+    pageBuilder: (context, animation, secondaryAnimation) => page,
+    transitionsBuilder: (context, animation, secondaryAnimation, child) {
+      final slideIn = Tween(
+        begin: const Offset(0.06, 0.0),
+        end: Offset.zero,
+      ).chain(CurveTween(curve: Curves.easeOutCubic));
+      final fadeIn = CurvedAnimation(parent: animation, curve: Curves.easeOut);
+      final slideOut = Tween(
+        begin: Offset.zero,
+        end: const Offset(-0.04, 0.0),
+      ).chain(CurveTween(curve: Curves.easeInCubic));
+      final fadeOut = CurvedAnimation(
+          parent: secondaryAnimation, curve: Curves.easeIn);
+
+      return FadeTransition(
+        opacity: Tween(begin: 0.0, end: 1.0).animate(fadeIn),
+        child: SlideTransition(
+          position: animation.drive(slideIn),
+          child: FadeTransition(
+            opacity: Tween(begin: 1.0, end: 0.85).animate(fadeOut),
+            child: SlideTransition(
+              position: secondaryAnimation.drive(slideOut),
+              child: child,
+            ),
+          ),
+        ),
+      );
+    },
+    transitionDuration: duration ?? const Duration(milliseconds: 380),
+    reverseTransitionDuration: duration ?? const Duration(milliseconds: 320),
+  );
+}
+
+/// Bottom-sheet style slide-up — for add screens, forms
+Route<T> slideUpRoute<T>(Widget page, {Duration? duration}) {
+  return PageRouteBuilder<T>(
+    pageBuilder: (context, animation, secondaryAnimation) => page,
+    transitionsBuilder: (context, animation, secondaryAnimation, child) {
+      final tween = Tween(
+        begin: const Offset(0.0, 0.12),
+        end: Offset.zero,
+      ).chain(CurveTween(curve: Curves.easeOutCubic));
+      final fade =
+          CurvedAnimation(parent: animation, curve: Curves.easeOut);
+
+      return FadeTransition(
+        opacity: Tween(begin: 0.0, end: 1.0).animate(fade),
+        child: SlideTransition(position: animation.drive(tween), child: child),
+      );
+    },
+    transitionDuration: duration ?? const Duration(milliseconds: 380),
+    reverseTransitionDuration: duration ?? const Duration(milliseconds: 300),
   );
 }

--- a/lib/core/widgets/spring_card.dart
+++ b/lib/core/widgets/spring_card.dart
@@ -1,0 +1,188 @@
+import 'package:flutter/material.dart';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SpringCard — Tap-to-scale card with spring animation
+// Gives cards a satisfying physical feel on interaction
+// ─────────────────────────────────────────────────────────────────────────────
+
+class SpringCard extends StatefulWidget {
+  final Widget child;
+  final VoidCallback? onTap;
+  final VoidCallback? onLongPress;
+  final double scale;
+  final Duration duration;
+  final Curve curve;
+  final BorderRadius? borderRadius;
+
+  const SpringCard({
+    super.key,
+    required this.child,
+    this.onTap,
+    this.onLongPress,
+    this.scale = 0.97,
+    this.duration = const Duration(milliseconds: 120),
+    this.curve = Curves.easeInOut,
+    this.borderRadius,
+  });
+
+  @override
+  State<SpringCard> createState() => _SpringCardState();
+}
+
+class _SpringCardState extends State<SpringCard>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _scaleAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: widget.duration,
+    );
+    _scaleAnimation = Tween<double>(
+      begin: 1.0,
+      end: widget.scale,
+    ).animate(CurvedAnimation(parent: _controller, curve: widget.curve));
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _handleTapDown(TapDownDetails _) => _controller.forward();
+
+  void _handleTapUp(TapUpDetails _) {
+    _controller.reverse();
+  }
+
+  void _handleTapCancel() => _controller.reverse();
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: widget.onTap,
+      onLongPress: widget.onLongPress,
+      onTapDown: widget.onTap != null ? _handleTapDown : null,
+      onTapUp: widget.onTap != null ? _handleTapUp : null,
+      onTapCancel: widget.onTap != null ? _handleTapCancel : null,
+      child: AnimatedBuilder(
+        animation: _scaleAnimation,
+        builder: (context, child) => Transform.scale(
+          scale: _scaleAnimation.value,
+          child: child,
+        ),
+        child: ClipRRect(
+          borderRadius: widget.borderRadius ?? BorderRadius.circular(12),
+          child: widget.child,
+        ),
+      ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ScaleFadeIn — Staggered entrance animation for lists
+// ─────────────────────────────────────────────────────────────────────────────
+
+class ScaleFadeIn extends StatefulWidget {
+  final Widget child;
+  final int index;
+  final Duration baseDuration;
+  final Duration stagger;
+
+  const ScaleFadeIn({
+    super.key,
+    required this.child,
+    this.index = 0,
+    this.baseDuration = const Duration(milliseconds: 400),
+    this.stagger = const Duration(milliseconds: 60),
+  });
+
+  @override
+  State<ScaleFadeIn> createState() => _ScaleFadeInState();
+}
+
+class _ScaleFadeInState extends State<ScaleFadeIn>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _ctrl;
+  late final Animation<double> _fade;
+  late final Animation<double> _scale;
+
+  @override
+  void initState() {
+    super.initState();
+    _ctrl = AnimationController(vsync: this, duration: widget.baseDuration);
+    _fade = CurvedAnimation(parent: _ctrl, curve: Curves.easeOut);
+    _scale = Tween(begin: 0.94, end: 1.0).animate(
+      CurvedAnimation(parent: _ctrl, curve: Curves.easeOutBack),
+    );
+
+    final delay = widget.stagger * widget.index;
+    Future.delayed(delay, () {
+      if (mounted) _ctrl.forward();
+    });
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FadeTransition(
+      opacity: _fade,
+      child: ScaleTransition(scale: _scale, child: widget.child),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PulseWidget — Subtle attention pulse for empty states / CTAs
+// ─────────────────────────────────────────────────────────────────────────────
+
+class PulseWidget extends StatefulWidget {
+  final Widget child;
+  final Duration period;
+
+  const PulseWidget({
+    super.key,
+    required this.child,
+    this.period = const Duration(seconds: 2),
+  });
+
+  @override
+  State<PulseWidget> createState() => _PulseWidgetState();
+}
+
+class _PulseWidgetState extends State<PulseWidget>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _ctrl;
+  late final Animation<double> _scale;
+
+  @override
+  void initState() {
+    super.initState();
+    _ctrl = AnimationController(vsync: this, duration: widget.period)
+      ..repeat(reverse: true);
+    _scale = Tween(begin: 1.0, end: 1.06).animate(
+      CurvedAnimation(parent: _ctrl, curve: Curves.easeInOutSine),
+    );
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ScaleTransition(scale: _scale, child: widget.child);
+  }
+}

--- a/lib/features/balances/screens/group_detail_screen.dart
+++ b/lib/features/balances/screens/group_detail_screen.dart
@@ -469,13 +469,13 @@ class _GroupDetailScreenState extends ConsumerState<GroupDetailScreen>
                 case 'members':
                   Navigator.push(
                     context,
-                    slideRoute(ManageMembersScreen(groupId: widget.group.id)),
+                    slideUpRoute(ManageMembersScreen(groupId: widget.group.id)),
                   );
                   break;
                 case 'statistics':
                   Navigator.push(
                     context,
-                    slideRoute(StatisticsScreen(
+                    slideUpRoute(StatisticsScreen(
                       groupId: widget.group.id,
                       groupName: _groupName,
                     )),
@@ -1119,7 +1119,7 @@ class _ExpensesTabState extends ConsumerState<_ExpensesTab> {
         onTap: () {
           Navigator.push(
             context,
-            slideRoute(ExpenseDetailScreen(
+            sharedAxisRoute(ExpenseDetailScreen(
               expense: expense,
               group: group ?? widget.group,
             )),
@@ -1356,7 +1356,7 @@ class _BalancesTab extends ConsumerWidget {
                           onTap: () {
                             Navigator.push(
                               context,
-                              slideRoute(MemberDetailScreen(
+                              sharedAxisRoute(MemberDetailScreen(
                                 memberId: mcb.member.id,
                                 groupId: groupId,
                                 memberName: mcb.member.name,
@@ -1423,7 +1423,7 @@ class _BalancesTab extends ConsumerWidget {
                           onTap: () {
                             Navigator.push(
                               context,
-                              slideRoute(MemberDetailScreen(
+                              sharedAxisRoute(MemberDetailScreen(
                                 memberId: mb.member.id,
                                 groupId: groupId,
                                 memberName: mb.member.name,
@@ -1477,7 +1477,7 @@ class _BalancesTab extends ConsumerWidget {
                 child: FilledButton.icon(
                   onPressed: () => Navigator.push(
                     context,
-                    slideRoute(SettleUpScreen(group: group)),
+                    slideUpRoute(SettleUpScreen(group: group)),
                   ),
                   icon: const Icon(Icons.handshake_outlined),
                   label: const Text('Settle Up'),

--- a/lib/features/expenses/screens/expense_detail_screen.dart
+++ b/lib/features/expenses/screens/expense_detail_screen.dart
@@ -104,7 +104,7 @@ class _ExpenseDetailScreenState extends ConsumerState<ExpenseDetailScreen> {
             onPressed: () {
               Navigator.push(
                 context,
-                slideRoute(AddExpenseScreen(
+                slideUpRoute(AddExpenseScreen(
                   group: widget.group,
                   expense: expense,
                 )),

--- a/lib/features/groups/screens/home_screen.dart
+++ b/lib/features/groups/screens/home_screen.dart
@@ -9,6 +9,7 @@ import '../../../core/services/deep_link_service.dart';
 import '../../../core/services/recurring_expense_service.dart';
 import '../../../core/sync/sync_service.dart';
 import '../../../core/widgets/sync_indicator.dart';
+import '../../../core/widgets/spring_card.dart';
 import '../../../core/utils/currency_utils.dart';
 import '../../../core/theme/app_theme.dart';
 import '../models/group_type.dart';
@@ -87,7 +88,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   void _navigateToJoin(String code) {
     Navigator.push(
       context,
-      slideRoute(JoinGroupScreen(shareCode: code)),
+      slideUpRoute(JoinGroupScreen(shareCode: code)),
     );
   }
 
@@ -132,7 +133,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         // Pass prefetched data to avoid double network call
         Navigator.push(
           context,
-          slideRoute(JoinGroupScreen(shareCode: code, prefetchedGroupData: cloudGroup)),
+          slideUpRoute(JoinGroupScreen(shareCode: code, prefetchedGroupData: cloudGroup)),
         );
         return;
       }
@@ -143,7 +144,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       if (group != null && mounted) {
         Navigator.push(
           context,
-          slideRoute(GroupDetailScreen(group: group)),
+          sharedAxisRoute(GroupDetailScreen(group: group)),
         );
       } else if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -230,26 +231,22 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
             itemCount: groups.length,
             itemBuilder: (context, index) {
               final group = groups[index];
-              return Padding(
+              return ScaleFadeIn(
+                index: index,
+                child: Padding(
                 padding: const EdgeInsets.only(bottom: 8),
-                child: Card(
-                  child: Tooltip(
-                    message: 'Hold to delete group',
-                    triggerMode: TooltipTriggerMode.longPress,
-                    child: InkWell(
-                      borderRadius: BorderRadius.circular(16),
-                      onTap: () {
-                      debugPrint('[PERF] HomeScreen: tapped group "${group.name}" (${group.id})');
-                      final sw = Stopwatch()..start();
-                      // BUG-06 fix: listenToGroup is now started in GroupDetailScreen.initState()
-                      // to ensure proper lifecycle ownership. Removed from here.
-                      Navigator.push(
-                        context,
-                        slideRoute(GroupDetailScreen(group: group)),
-                      );
-                      debugPrint('[PERF] HomeScreen: Navigator.push called at ${sw.elapsedMilliseconds}ms');
-                    },
-                    onLongPress: () {
+                child: SpringCard(
+                  borderRadius: BorderRadius.circular(12),
+                  onTap: () {
+                    debugPrint('[PERF] HomeScreen: tapped group "${group.name}" (${group.id})');
+                    final sw = Stopwatch()..start();
+                    Navigator.push(
+                      context,
+                      sharedAxisRoute(GroupDetailScreen(group: group)),
+                    );
+                    debugPrint('[PERF] HomeScreen: Navigator.push called at ${sw.elapsedMilliseconds}ms');
+                  },
+                  onLongPress: () {
                       showCupertinoModalPopup<void>(
                         context: context,
                         builder: (ctx) => CupertinoActionSheet(
@@ -275,6 +272,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                         ),
                       );
                     },
+                    child: Container(
+                    color: Theme.of(context).cardTheme.color,
                     child: Padding(
                       padding: const EdgeInsets.all(16),
                       child: Row(
@@ -386,10 +385,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                         ],
                       ),
                     ),
+                    ), // Container
                   ),
-                  ), // closes Tooltip
                 ),
-              );
+              ));
             },
           );
         },
@@ -400,7 +399,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         onPressed: () {
           Navigator.push(
             context,
-            slideRoute(const AddGroupScreen()),
+            slideUpRoute(const AddGroupScreen()),
           );
         },
         tooltip: 'New Group',


### PR DESCRIPTION
## ✨ Iteration 18 — Micro-interactions + Polish

### Navigation System Overhaul (app_routes.dart)
4 semantic route types, each tuned for its use case:

| Route | When | Curve | Duration |
|-------|------|-------|----------|
| `sharedAxisRoute` | Peer screens (Group→Detail, Detail→Member) | easeOutCubic + fade | 380ms / 320ms back |
| `slideUpRoute` | Additive/form screens (AddGroup, AddExpense) | easeOutCubic + fade | 380ms / 300ms back |
| `fadeRoute` | Replacements / overlays | easeInOut | 280ms / 220ms back |
| `slideRoute` | Legacy explicit slide | easeInOutCubic | 350ms |

### New: spring_card.dart
Three reusable micro-interaction components:

**SpringCard** — Physical tap feedback
```dart
SpringCard(
  onTap: () => Navigator.push(...),
  child: ...,
)
// → scales to 0.97 on press, springs back on release
```

**ScaleFadeIn** — Staggered list entrance
```dart
ScaleFadeIn(index: index, child: groupCard)
// → items fade+scale in 60ms apart (easeOutBack)
```

**PulseWidget** — Attention for empty states
```dart
PulseWidget(child: ctaButton)
// → gentle 1.0→1.06 breathing scale
```

### home_screen.dart
- Group cards: `slideRoute` → `sharedAxisRoute`
- JoinGroup/AddGroup FAB: `slideRoute` → `slideUpRoute`
- All cards wrapped in `SpringCard` + `ScaleFadeIn` for physical feel + entrance animation

### group_detail_screen.dart
- ExpenseDetail / MemberDetail → `sharedAxisRoute`
- SettleUp / ManageMembers / Statistics → `slideUpRoute`

### expense_detail_screen.dart
- Edit expense → `slideUpRoute`