### PR TITLE
perf(#130): virtualized ListView.builder in settle_up_screen

### DIFF
--- a/lib/features/settlements/screens/settle_up_screen.dart
+++ b/lib/features/settlements/screens/settle_up_screen.dart
@@ -50,45 +50,64 @@ class _SettleUpScreenState extends ConsumerState<SettleUpScreen> {
             return _buildAllSettledView(context);
           }
 
-          return ListView(
+          // Build a flat list of items for virtualized rendering.
+          // Layout: [header, settleAllBtn?, sectionTitle, ...settlementCards]
+          // Using ListView.builder ensures O(1) rendering even for large lists.
+          final hasSettleAll = settlements.length > 1;
+          // Fixed header items: header card + optional settle-all btn + section title
+          const headerCount = 1; // header card (always)
+          final settleAllCount = hasSettleAll ? 1 : 0;
+          const sectionTitleCount = 1;
+          final leadingCount = headerCount + settleAllCount + sectionTitleCount;
+
+          return ListView.builder(
             padding: const EdgeInsets.all(16),
-            children: [
-              // Header card
-              _buildHeaderCard(context, settlements),
-              const SizedBox(height: 16),
-
-              // Settle All button — only when > 1 debt (Change 4)
-              if (settlements.length > 1) ...[
-                FilledButton.icon(
-                  onPressed: () => _settleAll(context, ref, settlements),
-                  icon: const Icon(Icons.done_all),
-                  label: Text('Settle All (${settlements.length} debts)'),
-                  style: FilledButton.styleFrom(
-                    padding: const EdgeInsets.symmetric(vertical: 14),
-                  ),
-                ),
-                const SizedBox(height: 16),
-              ],
-
-              Text(
-                'Pending Debts',
-                style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                      fontWeight: FontWeight.bold,
-                    ),
-              ),
-              const SizedBox(height: 8),
-
-              ...settlements.map((s) {
-                final key = _settlementKey(s);
-                final isProcessing = _processingKeys.contains(key);
-                return _SettlementCard(
-                  settlement: s,
-                  currency: widget.group.currency,
-                  isProcessing: isProcessing,
-                  onMarkSettled: () => _markAsSettled(context, ref, s, key),
+            itemCount: leadingCount + settlements.length,
+            itemBuilder: (context, index) {
+              if (index == 0) {
+                // Header card
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: 16),
+                  child: _buildHeaderCard(context, settlements),
                 );
-              }),
-            ],
+              }
+              if (hasSettleAll && index == 1) {
+                // Settle All button
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: 16),
+                  child: FilledButton.icon(
+                    onPressed: () => _settleAll(context, ref, settlements),
+                    icon: const Icon(Icons.done_all),
+                    label: Text('Settle All (${settlements.length} debts)'),
+                    style: FilledButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(vertical: 14),
+                    ),
+                  ),
+                );
+              }
+              if (index == leadingCount - 1) {
+                // Section title "Pending Debts"
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: 8),
+                  child: Text(
+                    'Pending Debts',
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
+                  ),
+                );
+              }
+              // Settlement card
+              final s = settlements[index - leadingCount];
+              final key = _settlementKey(s);
+              final isProcessing = _processingKeys.contains(key);
+              return _SettlementCard(
+                settlement: s,
+                currency: widget.group.currency,
+                isProcessing: isProcessing,
+                onMarkSettled: () => _markAsSettled(context, ref, s, key),
+              );
+            },
           );
         },
         loading: () => const Center(child: CircularProgressIndicator()),


### PR DESCRIPTION
## Audit: All expense-related list screens

| Screen | Before | After |
|--------|--------|-------|
| `group_detail_screen.dart` (expense list) | ✅ ListView.builder | No change |
| `activity_tab.dart` | ✅ ListView.builder | No change |
| `global_activity_screen.dart` | ✅ ListView.builder | No change |
| `home_screen.dart` (groups list) | ✅ ListView.builder | No change |
| `settle_up_screen.dart` | ❌ ListView + spread | ✅ ListView.builder |
| `settings_screen.dart` | ListView (static form, not a data list) | Acceptable |
| `add_group_screen.dart` | ListView (static form) | Acceptable |

## Change
`settle_up_screen.dart`: Converted mixed-content list to `ListView.builder` with indexed layout:
- index 0: header card
- index 1: settle-all button (if multiple debts)
- index N-1: "Pending Debts" section title
- index N+: settlement cards (virtualized)

This ensures O(1) rendering for all data-driven lists in the app.

Closes #130